### PR TITLE
fix: review-requestedラベルの遷移が動作しない問題を修正

### DIFF
--- a/internal/watcher/actions/review_action.go
+++ b/internal/watcher/actions/review_action.go
@@ -63,8 +63,8 @@ func (a *ReviewAction) Execute(ctx context.Context, issue *github.Issue) error {
 	// 処理開始
 	a.stateManager.SetState(issueNumber, watcher.IssueStateReview, watcher.IssueStatusProcessing)
 
-	// ラベル遷移（status:needs-review → status:reviewing）
-	if err := a.labelManager.TransitionLabel(ctx, int(issueNumber), "status:needs-review", "status:reviewing"); err != nil {
+	// ラベル遷移（status:review-requested → status:reviewing）
+	if err := a.labelManager.TransitionLabel(ctx, int(issueNumber), "status:review-requested", "status:reviewing"); err != nil {
 		a.stateManager.MarkAsFailed(issueNumber, watcher.IssueStateReview)
 		return fmt.Errorf("failed to transition label: %w", err)
 	}
@@ -99,5 +99,5 @@ func (a *ReviewAction) Execute(ctx context.Context, issue *github.Issue) error {
 
 // CanExecute はレビューフェーズのアクションが実行可能かを判定する
 func (a *ReviewAction) CanExecute(issue *github.Issue) bool {
-	return hasLabel(issue, "status:needs-review")
+	return hasLabel(issue, "status:review-requested")
 }

--- a/internal/watcher/actions/review_action_test.go
+++ b/internal/watcher/actions/review_action_test.go
@@ -19,7 +19,7 @@ func TestReviewAction_Execute(t *testing.T) {
 			Number: github.Int(int(issueNumber)),
 			Title:  github.String("Test Issue"),
 			Labels: []*github.Label{
-				{Name: github.String("status:needs-review")},
+				{Name: github.String("status:review-requested")},
 			},
 		}
 
@@ -37,7 +37,7 @@ func TestReviewAction_Execute(t *testing.T) {
 		mockState.On("SetState", issueNumber, watcher.IssueStateReview, watcher.IssueStatusProcessing)
 
 		// ラベル遷移
-		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:needs-review", "status:reviewing").Return(nil)
+		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:review-requested", "status:reviewing").Return(nil)
 
 		// tmuxウィンドウへの切り替え
 		mockTmux.On("SwitchToIssueWindow", sessionName, int(issueNumber)).Return(nil)
@@ -78,7 +78,7 @@ func TestReviewAction_Execute(t *testing.T) {
 			Number: github.Int(int(issueNumber)),
 			Title:  github.String("Test Issue"),
 			Labels: []*github.Label{
-				{Name: github.String("status:needs-review")},
+				{Name: github.String("status:review-requested")},
 			},
 		}
 
@@ -113,7 +113,7 @@ func TestReviewAction_Execute(t *testing.T) {
 			Number: github.Int(int(issueNumber)),
 			Title:  github.String("Test Issue"),
 			Labels: []*github.Label{
-				{Name: github.String("status:needs-review")},
+				{Name: github.String("status:review-requested")},
 			},
 		}
 
@@ -131,7 +131,7 @@ func TestReviewAction_Execute(t *testing.T) {
 		mockState.On("SetState", issueNumber, watcher.IssueStateReview, watcher.IssueStatusProcessing)
 
 		// ラベル遷移失敗
-		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:needs-review", "status:reviewing").Return(assert.AnError)
+		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:review-requested", "status:reviewing").Return(assert.AnError)
 
 		// 処理失敗
 		mockState.On("MarkAsFailed", issueNumber, watcher.IssueStateReview)
@@ -159,7 +159,7 @@ func TestReviewAction_Execute(t *testing.T) {
 			Number: github.Int(int(issueNumber)),
 			Title:  github.String("Test Issue"),
 			Labels: []*github.Label{
-				{Name: github.String("status:needs-review")},
+				{Name: github.String("status:review-requested")},
 			},
 		}
 
@@ -177,7 +177,7 @@ func TestReviewAction_Execute(t *testing.T) {
 		mockState.On("SetState", issueNumber, watcher.IssueStateReview, watcher.IssueStatusProcessing)
 
 		// ラベル遷移
-		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:needs-review", "status:reviewing").Return(nil)
+		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:review-requested", "status:reviewing").Return(nil)
 
 		// tmuxウィンドウへの切り替え
 		mockTmux.On("SwitchToIssueWindow", sessionName, int(issueNumber)).Return(nil)
@@ -206,12 +206,12 @@ func TestReviewAction_Execute(t *testing.T) {
 }
 
 func TestReviewAction_CanExecute(t *testing.T) {
-	t.Run("実行可能: status:needs-reviewラベルあり", func(t *testing.T) {
+	t.Run("実行可能: status:review-requestedラベルあり", func(t *testing.T) {
 		// Arrange
 		issue := &github.Issue{
 			Number: github.Int(28),
 			Labels: []*github.Label{
-				{Name: github.String("status:needs-review")},
+				{Name: github.String("status:review-requested")},
 				{Name: github.String("enhancement")},
 			},
 		}
@@ -225,7 +225,7 @@ func TestReviewAction_CanExecute(t *testing.T) {
 		assert.True(t, canExecute)
 	})
 
-	t.Run("実行不可: status:needs-reviewラベルなし", func(t *testing.T) {
+	t.Run("実行不可: status:review-requestedラベルなし", func(t *testing.T) {
 		// Arrange
 		issue := &github.Issue{
 			Number: github.Int(28),


### PR DESCRIPTION
## 概要
レビューフェーズで `status:review-requested` ラベルを付けても `status:reviewing` への遷移が行われない問題を修正しました。

## 関連するIssue
fixes #39

## 変更内容
- `ReviewAction.CanExecute()` メソッドで使用していた誤ったラベル名 `status:needs-review` を正しい `status:review-requested` に修正
- `ReviewAction.Execute()` メソッドのラベル遷移処理でも同様の修正を実施
- テストケースを正しいラベル名に更新し、TDDアプローチで実装

## テスト結果
- [x] ユニットテスト実行済み（`go test ./internal/watcher/actions`）
- [x] システムテスト実行済み（`go test ./...`）
- [x] go fmt 実行済み
- [x] go vet 実行済み

## レビューポイント
- ラベル名の修正が適切に行われているか
- 他のフェーズ（Plan、Implementation）との一貫性が保たれているか
- テストが適切に更新されているか