### PR TITLE
fix: ActionManagerExtendedでstatus:review-requestedラベルを使用するように修正

### DIFF
--- a/internal/watcher/action_manager_extended.go
+++ b/internal/watcher/action_manager_extended.go
@@ -61,7 +61,7 @@ func (m *ActionManagerExtended) GetActionForIssue(issue *github.Issue) ActionExe
 	if hasLabel(issue, "status:ready") {
 		return m.factory.CreateImplementationAction()
 	}
-	if hasLabel(issue, "status:needs-review") {
+	if hasLabel(issue, "status:review-requested") {
 		return m.factory.CreateReviewAction()
 	}
 

--- a/internal/watcher/action_manager_test.go
+++ b/internal/watcher/action_manager_test.go
@@ -128,7 +128,7 @@ func TestActionManagerExtended_ExecuteAction(t *testing.T) {
 		issue := &github.Issue{
 			Number: github.Int(issueNumber),
 			Labels: []*github.Label{
-				{Name: github.String("status:needs-review")},
+				{Name: github.String("status:review-requested")},
 			},
 		}
 


### PR DESCRIPTION
## 概要
PR #40 では `ReviewAction` クラスの修正のみ行いましたが、`ActionManagerExtended` クラスでも同じ問題がありました。
この PR では、`ActionManagerExtended` の `GetActionForIssue` メソッドで使用しているラベル名を修正します。

## 関連するIssue
refs #39

## 変更内容
- `ActionManagerExtended.GetActionForIssue()` メソッドで使用していた誤ったラベル名 `status:needs-review` を正しい `status:review-requested` に修正
- 関連するテストケースも更新

## テスト結果
- [x] ユニットテスト実行済み（`go test ./internal/watcher`）
- [x] go fmt 実行済み
- [x] go vet 実行済み

## レビューポイント
- ActionManagerExtended での適切なアクション選択が行われているか
- テストケースが正しく更新されているか