### PR TITLE
fix: LabelManagerで使用するラベル名をstatus:review-requestedに統一

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -185,14 +185,14 @@ github:
   labels:
     plan: "status:planning"
     ready: "status:ready-to-dev"
-    review: "status:needs-review"
+    review: "status:review-requested"
 `,
 			envVars: map[string]string{
 				"GITHUB_TOKEN": "env-token-123",
 			},
 			wantToken:    "env-token-123",
 			wantInterval: 10 * time.Second,
-			wantLabels:   []string{"status:planning", "status:ready-to-dev", "status:needs-review"},
+			wantLabels:   []string{"status:planning", "status:ready-to-dev", "status:review-requested"},
 		},
 		{
 			name: "OSOBA_GITHUB_TOKEN環境変数が優先される",

--- a/internal/github/integration_test.go
+++ b/internal/github/integration_test.go
@@ -107,7 +107,7 @@ func TestLabelManagerIntegration(t *testing.T) {
 			"status:planning",
 			"status:ready",
 			"status:implementing",
-			"status:needs-review",
+			"status:review-requested",
 			"status:reviewing",
 		}
 

--- a/internal/github/label_manager.go
+++ b/internal/github/label_manager.go
@@ -62,8 +62,8 @@ func (lm *LabelManager) initializeLabelDefinitions() {
 		Description: "Ready for implementation",
 	}
 
-	lm.labelDefinitions["status:needs-review"] = LabelDefinition{
-		Name:        "status:needs-review",
+	lm.labelDefinitions["status:review-requested"] = LabelDefinition{
+		Name:        "status:review-requested",
 		Color:       "d93f0b",
 		Description: "Review requested",
 	}
@@ -92,7 +92,7 @@ func (lm *LabelManager) initializeLabelDefinitions() {
 func (lm *LabelManager) initializeTransitionRules() {
 	lm.transitionRules["status:needs-plan"] = "status:planning"
 	lm.transitionRules["status:ready"] = "status:implementing"
-	lm.transitionRules["status:needs-review"] = "status:reviewing"
+	lm.transitionRules["status:review-requested"] = "status:reviewing"
 }
 
 // GetLabelDefinitions returns all label definitions

--- a/internal/github/label_manager_test.go
+++ b/internal/github/label_manager_test.go
@@ -75,7 +75,7 @@ func TestLabelManager_GetLabelDefinitions(t *testing.T) {
 	// トリガーラベルの確認
 	assert.Contains(t, definitions, "status:needs-plan")
 	assert.Contains(t, definitions, "status:ready")
-	assert.Contains(t, definitions, "status:needs-review")
+	assert.Contains(t, definitions, "status:review-requested")
 
 	// 実行中ラベルの確認
 	assert.Contains(t, definitions, "status:planning")
@@ -96,7 +96,7 @@ func TestLabelManager_GetTransitionRules(t *testing.T) {
 
 	assert.Equal(t, "status:planning", rules["status:needs-plan"])
 	assert.Equal(t, "status:implementing", rules["status:ready"])
-	assert.Equal(t, "status:reviewing", rules["status:needs-review"])
+	assert.Equal(t, "status:reviewing", rules["status:review-requested"])
 }
 
 func TestLabelManager_TransitionLabel(t *testing.T) {
@@ -207,7 +207,7 @@ func TestLabelManager_EnsureLabelsExist(t *testing.T) {
 	}{
 		{
 			name:           "全てのラベルが既に存在する場合",
-			existingLabels: []string{"status:needs-plan", "status:planning", "status:ready", "status:implementing", "status:needs-review", "status:reviewing"},
+			existingLabels: []string{"status:needs-plan", "status:planning", "status:ready", "status:implementing", "status:review-requested", "status:reviewing"},
 			setupMocks: func(m *MockLabelService) {
 				// 既存ラベルの取得
 				m.On("ListLabels", mock.Anything, "owner", "repo", (*github.ListOptions)(nil)).
@@ -216,7 +216,7 @@ func TestLabelManager_EnsureLabelsExist(t *testing.T) {
 						{Name: github.String("status:planning")},
 						{Name: github.String("status:ready")},
 						{Name: github.String("status:implementing")},
-						{Name: github.String("status:needs-review")},
+						{Name: github.String("status:review-requested")},
 						{Name: github.String("status:reviewing")},
 					}, &github.Response{}, nil)
 			},
@@ -243,8 +243,8 @@ func TestLabelManager_EnsureLabelsExist(t *testing.T) {
 				})).Return(&github.Label{Name: github.String("status:implementing")}, &github.Response{}, nil)
 
 				m.On("CreateLabel", mock.Anything, "owner", "repo", mock.MatchedBy(func(label *github.Label) bool {
-					return *label.Name == "status:needs-review" && *label.Color == "d93f0b"
-				})).Return(&github.Label{Name: github.String("status:needs-review")}, &github.Response{}, nil)
+					return *label.Name == "status:review-requested" && *label.Color == "d93f0b"
+				})).Return(&github.Label{Name: github.String("status:review-requested")}, &github.Response{}, nil)
 
 				m.On("CreateLabel", mock.Anything, "owner", "repo", mock.MatchedBy(func(label *github.Label) bool {
 					return *label.Name == "status:reviewing" && *label.Color == "d93f0b"

--- a/internal/github/label_manager_with_retry_test.go
+++ b/internal/github/label_manager_with_retry_test.go
@@ -154,7 +154,7 @@ func TestLabelManagerWithRetry_EnsureLabelsExistWithRetry(t *testing.T) {
 					"status:planning",
 					"status:ready",
 					"status:implementing",
-					"status:needs-review",
+					"status:review-requested",
 					"status:reviewing",
 				}
 
@@ -180,7 +180,7 @@ func TestLabelManagerWithRetry_EnsureLabelsExistWithRetry(t *testing.T) {
 						{Name: github.String("status:planning")},
 						{Name: github.String("status:ready")},
 						{Name: github.String("status:implementing")},
-						{Name: github.String("status:needs-review")},
+						{Name: github.String("status:review-requested")},
 						{Name: github.String("status:reviewing")},
 					}, &github.Response{}, nil).Once()
 			},


### PR DESCRIPTION
## 概要
LabelManagerで使用するラベル名を`status:review-requested`に統一する修正です。

## 関連するIssue
fixes #39

## 変更内容
- `internal/github/label_manager.go`でラベル定義と遷移ルールを修正
  - `status:needs-review` → `status:review-requested`に変更
- 関連するテストファイルを更新
  - `internal/github/label_manager_test.go`
  - `internal/github/label_manager_with_retry_test.go`
  - `internal/github/integration_test.go`
  - `cmd/integration_test.go`

## テスト結果
- [x] ユニットテスト実行済み（全て成功）
- [x] Go fmt/vet実行済み

## レビューポイント
- LabelManagerのラベル定義が正しく更新されているか
- 全てのテストケースで一貫したラベル名が使用されているか
EOF < /dev/null