### PR TITLE
fix: tmuxウィンドウのフェーズ別命名を実装

### DIFF
--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -330,3 +330,57 @@ func CreateOrReplaceWindowWithExecutor(sessionName, windowName string, executor 
 
 	return nil
 }
+
+// CreateWindowForIssueWithExecutor はIssue番号とフェーズに基づいてウィンドウを作成する
+func CreateWindowForIssueWithExecutor(sessionName string, issueNumber int, phase string, executor CommandExecutor) error {
+	// フェーズの検証とウィンドウ名の生成
+	windowName, err := GetWindowNameWithPhase(issueNumber, phase)
+	if err != nil {
+		return err
+	}
+
+	if logger := GetLogger(); logger != nil {
+		logger.Info("Issue用フェーズウィンドウ作成開始",
+			"operation", "create_window_for_issue_with_phase",
+			"session_name", sessionName,
+			"issue_number", issueNumber,
+			"phase", phase,
+			"window_name", windowName)
+	}
+
+	// ウィンドウが既に存在する場合はスキップ
+	exists, err := WindowExistsWithExecutor(sessionName, windowName, executor)
+	if err != nil {
+		return fmt.Errorf("failed to check window existence: %w", err)
+	}
+	if exists {
+		if logger := GetLogger(); logger != nil {
+			logger.Info("フェーズウィンドウは既に存在します",
+				"session_name", sessionName,
+				"window_name", windowName)
+		}
+		return nil
+	}
+
+	return CreateWindowWithExecutor(sessionName, windowName, executor)
+}
+
+// SwitchToIssueWindowWithExecutor はIssue番号とフェーズに基づいてウィンドウに切り替える
+func SwitchToIssueWindowWithExecutor(sessionName string, issueNumber int, phase string, executor CommandExecutor) error {
+	// フェーズの検証とウィンドウ名の生成
+	windowName, err := GetWindowNameWithPhase(issueNumber, phase)
+	if err != nil {
+		return err
+	}
+
+	if logger := GetLogger(); logger != nil {
+		logger.Info("Issue用フェーズウィンドウへ切り替え",
+			"operation", "switch_to_issue_window_with_phase",
+			"session_name", sessionName,
+			"issue_number", issueNumber,
+			"phase", phase,
+			"window_name", windowName)
+	}
+
+	return SwitchToWindowWithExecutor(sessionName, windowName, executor)
+}

--- a/internal/tmux/window_issue_test.go
+++ b/internal/tmux/window_issue_test.go
@@ -1,0 +1,262 @@
+package tmux
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateWindowForIssue(t *testing.T) {
+	t.Run("正常系: Issue番号とフェーズからウィンドウが作成される", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "plan"
+		expectedWindowName := "33-plan"
+
+		mockExec := new(MockCommandExecutor)
+		// WindowExists: ウィンドウが存在しない
+		mockExec.On("Execute", "tmux", "list-windows", "-t", sessionName, "-F", "#{window_name}").Return("other-window", nil)
+		// CreateWindow
+		mockExec.On("Execute", "tmux", "new-window", "-t", sessionName, "-n", expectedWindowName).Return("", nil)
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: implementフェーズのウィンドウ作成", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "implement"
+		expectedWindowName := "33-implement"
+
+		mockExec := new(MockCommandExecutor)
+		// WindowExists: ウィンドウが存在しない
+		mockExec.On("Execute", "tmux", "list-windows", "-t", sessionName, "-F", "#{window_name}").Return("33-plan\nother-window", nil)
+		// CreateWindow
+		mockExec.On("Execute", "tmux", "new-window", "-t", sessionName, "-n", expectedWindowName).Return("", nil)
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: reviewフェーズのウィンドウ作成", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "review"
+		expectedWindowName := "33-review"
+
+		mockExec := new(MockCommandExecutor)
+		// WindowExists: ウィンドウが存在しない
+		mockExec.On("Execute", "tmux", "list-windows", "-t", sessionName, "-F", "#{window_name}").Return("33-plan\n33-implement", nil)
+		// CreateWindow
+		mockExec.On("Execute", "tmux", "new-window", "-t", sessionName, "-n", expectedWindowName).Return("", nil)
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: ウィンドウが既に存在する場合はスキップ", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "plan"
+
+		mockExec := new(MockCommandExecutor)
+		// WindowExists: ウィンドウが既に存在する
+		mockExec.On("Execute", "tmux", "list-windows", "-t", sessionName, "-F", "#{window_name}").Return("33-plan\nother-window", nil)
+		// CreateWindowは呼ばれない
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: 無効なフェーズ", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "invalid"
+
+		mockExec := new(MockCommandExecutor)
+		// WindowExistsは呼ばれない
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid phase")
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: 空のフェーズ", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := ""
+
+		mockExec := new(MockCommandExecutor)
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid phase")
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: ウィンドウ作成に失敗", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "plan"
+		expectedWindowName := "33-plan"
+
+		mockExec := new(MockCommandExecutor)
+		// WindowExists: ウィンドウが存在しない
+		mockExec.On("Execute", "tmux", "list-windows", "-t", sessionName, "-F", "#{window_name}").Return("other-window", nil)
+		// CreateWindow: 失敗
+		mockExec.On("Execute", "tmux", "new-window", "-t", sessionName, "-n", expectedWindowName).Return("", errors.New("creation failed"))
+
+		// Act
+		err := CreateWindowForIssueWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "creation failed")
+		mockExec.AssertExpectations(t)
+	})
+}
+
+func TestSwitchToIssueWindow(t *testing.T) {
+	t.Run("正常系: Issue番号とフェーズからウィンドウに切り替える", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "plan"
+		expectedWindowName := "33-plan"
+		expectedTarget := sessionName + ":" + expectedWindowName
+
+		mockExec := new(MockCommandExecutor)
+		mockExec.On("Execute", "tmux", "select-window", "-t", expectedTarget).Return("", nil)
+
+		// Act
+		err := SwitchToIssueWindowWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: implementフェーズのウィンドウに切り替え", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "implement"
+		expectedWindowName := "33-implement"
+		expectedTarget := sessionName + ":" + expectedWindowName
+
+		mockExec := new(MockCommandExecutor)
+		mockExec.On("Execute", "tmux", "select-window", "-t", expectedTarget).Return("", nil)
+
+		// Act
+		err := SwitchToIssueWindowWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: reviewフェーズのウィンドウに切り替え", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "review"
+		expectedWindowName := "33-review"
+		expectedTarget := sessionName + ":" + expectedWindowName
+
+		mockExec := new(MockCommandExecutor)
+		mockExec.On("Execute", "tmux", "select-window", "-t", expectedTarget).Return("", nil)
+
+		// Act
+		err := SwitchToIssueWindowWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: 無効なフェーズ", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "invalid"
+
+		mockExec := new(MockCommandExecutor)
+
+		// Act
+		err := SwitchToIssueWindowWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid phase")
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: 空のフェーズ", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := ""
+
+		mockExec := new(MockCommandExecutor)
+
+		// Act
+		err := SwitchToIssueWindowWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid phase")
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: ウィンドウ切り替えに失敗", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 33
+		phase := "plan"
+		expectedWindowName := "33-plan"
+		expectedTarget := sessionName + ":" + expectedWindowName
+
+		mockExec := new(MockCommandExecutor)
+		mockExec.On("Execute", "tmux", "select-window", "-t", expectedTarget).Return("", errors.New("window not found"))
+
+		// Act
+		err := SwitchToIssueWindowWithExecutor(sessionName, issueNumber, phase, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to switch to window")
+		mockExec.AssertExpectations(t)
+	})
+}

--- a/internal/watcher/actions/implementation_action.go
+++ b/internal/watcher/actions/implementation_action.go
@@ -74,10 +74,10 @@ func (a *ImplementationAction) Execute(ctx context.Context, issue *github.Issue)
 		return fmt.Errorf("failed to transition label: %w", err)
 	}
 
-	// tmuxウィンドウへの切り替え（既存のウィンドウを使用）
-	if err := a.tmuxClient.SwitchToIssueWindow(a.sessionName, int(issueNumber)); err != nil {
+	// tmuxウィンドウ作成
+	if err := a.tmuxClient.CreateWindowForIssue(a.sessionName, int(issueNumber), "implement"); err != nil {
 		a.stateManager.MarkAsFailed(issueNumber, types.IssueStateImplementation)
-		return fmt.Errorf("failed to switch tmux window: %w", err)
+		return fmt.Errorf("failed to create tmux window: %w", err)
 	}
 
 	// mainブランチを最新化
@@ -125,7 +125,7 @@ func (a *ImplementationAction) Execute(ctx context.Context, issue *github.Issue)
 	}
 
 	// tmuxウィンドウ内でClaude実行
-	windowName := fmt.Sprintf("issue-%d", issueNumber)
+	windowName := fmt.Sprintf("%d-implement", issueNumber)
 	log.Printf("Executing Claude in tmux window for issue #%d", issueNumber)
 	if err := a.claudeExecutor.ExecuteInTmux(ctx, phaseConfig, templateVars, a.sessionName, windowName, worktreePath); err != nil {
 		a.stateManager.MarkAsFailed(issueNumber, types.IssueStateImplementation)

--- a/internal/watcher/actions/implementation_action_test.go
+++ b/internal/watcher/actions/implementation_action_test.go
@@ -43,7 +43,7 @@ func TestImplementationAction_Execute(t *testing.T) {
 		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:ready", "status:implementing").Return(nil)
 
 		// tmuxウィンドウへの切り替え
-		mockTmux.On("SwitchToIssueWindow", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "implement").Return(nil)
 
 		// mainブランチの更新
 		mockWorktree.On("UpdateMainBranch", ctx).Return(nil)
@@ -65,7 +65,7 @@ func TestImplementationAction_Execute(t *testing.T) {
 			IssueTitle:  "Test Issue",
 			RepoName:    "douhashi/osoba",
 		}
-		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "issue-28", workdir).Return(nil)
+		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "28-implement", workdir).Return(nil)
 
 		// 処理完了
 		mockState.On("MarkAsCompleted", issueNumber, types.IssueStateImplementation)
@@ -114,7 +114,7 @@ func TestImplementationAction_Execute(t *testing.T) {
 
 		// Assert
 		assert.NoError(t, err) // 処理済みはエラーではない
-		mockTmux.AssertNotCalled(t, "SwitchToIssueWindow")
+		mockTmux.AssertNotCalled(t, "CreateWindowForIssue")
 		mockLabel.AssertNotCalled(t, "TransitionLabel")
 		mockWorktree.AssertNotCalled(t, "UpdateMainBranch")
 		mockClaude.AssertNotCalled(t, "ExecuteInTmux")
@@ -162,7 +162,7 @@ func TestImplementationAction_Execute(t *testing.T) {
 		// Assert
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "transition label")
-		mockTmux.AssertNotCalled(t, "SwitchToIssueWindow")
+		mockTmux.AssertNotCalled(t, "CreateWindowForIssue")
 		mockWorktree.AssertNotCalled(t, "UpdateMainBranch")
 		mockClaude.AssertNotCalled(t, "ExecuteInTmux")
 		mockState.AssertExpectations(t)
@@ -200,7 +200,7 @@ func TestImplementationAction_Execute(t *testing.T) {
 		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:ready", "status:implementing").Return(nil)
 
 		// tmuxウィンドウへの切り替え
-		mockTmux.On("SwitchToIssueWindow", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "implement").Return(nil)
 
 		// mainブランチの更新
 		mockWorktree.On("UpdateMainBranch", ctx).Return(nil)
@@ -222,7 +222,7 @@ func TestImplementationAction_Execute(t *testing.T) {
 			IssueTitle:  "Test Issue",
 			RepoName:    "douhashi/osoba",
 		}
-		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "issue-28", workdir).Return(assert.AnError)
+		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "28-implement", workdir).Return(assert.AnError)
 
 		// 処理失敗
 		mockState.On("MarkAsFailed", issueNumber, types.IssueStateImplementation)

--- a/internal/watcher/actions/plan_action_complete.go
+++ b/internal/watcher/actions/plan_action_complete.go
@@ -90,7 +90,7 @@ func (a *PlanActionComplete) Execute(ctx context.Context, issue *github.Issue) e
 	}
 
 	// tmuxウィンドウ作成
-	if err := a.tmuxClient.CreateWindowForIssue(a.sessionName, int(issueNumber)); err != nil {
+	if err := a.tmuxClient.CreateWindowForIssue(a.sessionName, int(issueNumber), "plan"); err != nil {
 		a.stateManager.MarkAsFailed(issueNumber, types.IssueStatePlan)
 		return fmt.Errorf("failed to create tmux window: %w", err)
 	}

--- a/internal/watcher/actions/plan_action_complete_test.go
+++ b/internal/watcher/actions/plan_action_complete_test.go
@@ -96,7 +96,7 @@ func TestPlanActionComplete_Execute(t *testing.T) {
 		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:needs-plan", "status:planning").Return(nil)
 
 		// tmuxウィンドウ作成
-		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "plan").Return(nil)
 
 		// git worktree作成
 		workdir := "/tmp/osoba/worktree/28"
@@ -199,7 +199,7 @@ func TestPlanActionComplete_Execute(t *testing.T) {
 		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:needs-plan", "status:planning").Return(nil)
 
 		// tmuxウィンドウ作成
-		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "plan").Return(nil)
 
 		// git worktree作成失敗
 		mockGit.On("CreateWorktreeForIssue", int(issueNumber), "feat/#28-phase-action-execution").Return("", assert.AnError)

--- a/internal/watcher/actions/plan_action_test.go
+++ b/internal/watcher/actions/plan_action_test.go
@@ -18,13 +18,13 @@ type MockTmuxClient struct {
 	mock.Mock
 }
 
-func (m *MockTmuxClient) CreateWindowForIssue(sessionName string, issueNumber int) error {
-	args := m.Called(sessionName, issueNumber)
+func (m *MockTmuxClient) CreateWindowForIssue(sessionName string, issueNumber int, phase string) error {
+	args := m.Called(sessionName, issueNumber, phase)
 	return args.Error(0)
 }
 
-func (m *MockTmuxClient) SwitchToIssueWindow(sessionName string, issueNumber int) error {
-	args := m.Called(sessionName, issueNumber)
+func (m *MockTmuxClient) SwitchToIssueWindow(sessionName string, issueNumber int, phase string) error {
+	args := m.Called(sessionName, issueNumber, phase)
 	return args.Error(0)
 }
 
@@ -178,7 +178,7 @@ func TestPlanAction_Execute(t *testing.T) {
 		mockState.On("SetState", issueNumber, types.IssueStatePlan, types.IssueStatusProcessing)
 
 		// tmuxウィンドウ作成
-		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "plan").Return(nil)
 
 		// mainブランチ更新とworktree作成
 		mockWorktree.On("UpdateMainBranch", ctx).Return(nil)
@@ -186,7 +186,7 @@ func TestPlanAction_Execute(t *testing.T) {
 		mockWorktree.On("GetWorktreePath", int(issueNumber), git.PhasePlan).Return("/tmp/worktree/13-plan")
 
 		// Claude実行
-		mockClaude.On("ExecuteInTmux", ctx, config.Phases["plan"], mock.AnythingOfType("*claude.TemplateVariables"), sessionName, "issue-13", "/tmp/worktree/13-plan").Return(nil)
+		mockClaude.On("ExecuteInTmux", ctx, config.Phases["plan"], mock.AnythingOfType("*claude.TemplateVariables"), sessionName, "13-plan", "/tmp/worktree/13-plan").Return(nil)
 
 		// 処理完了
 		mockState.On("MarkAsCompleted", issueNumber, types.IssueStatePlan)

--- a/internal/watcher/actions/review_action.go
+++ b/internal/watcher/actions/review_action.go
@@ -74,10 +74,10 @@ func (a *ReviewAction) Execute(ctx context.Context, issue *github.Issue) error {
 		return fmt.Errorf("failed to transition label: %w", err)
 	}
 
-	// tmuxウィンドウへの切り替え（既存のウィンドウを使用）
-	if err := a.tmuxClient.SwitchToIssueWindow(a.sessionName, int(issueNumber)); err != nil {
+	// tmuxウィンドウ作成
+	if err := a.tmuxClient.CreateWindowForIssue(a.sessionName, int(issueNumber), "review"); err != nil {
 		a.stateManager.MarkAsFailed(issueNumber, types.IssueStateReview)
-		return fmt.Errorf("failed to switch tmux window: %w", err)
+		return fmt.Errorf("failed to create tmux window: %w", err)
 	}
 
 	// mainブランチを最新化
@@ -123,7 +123,7 @@ func (a *ReviewAction) Execute(ctx context.Context, issue *github.Issue) error {
 	}
 
 	// tmuxウィンドウ内でClaude実行
-	windowName := fmt.Sprintf("issue-%d", issueNumber)
+	windowName := fmt.Sprintf("%d-review", issueNumber)
 	log.Printf("Executing Claude in tmux window for issue #%d", issueNumber)
 	if err := a.claudeExecutor.ExecuteInTmux(ctx, phaseConfig, templateVars, a.sessionName, windowName, worktreePath); err != nil {
 		a.stateManager.MarkAsFailed(issueNumber, types.IssueStateReview)

--- a/internal/watcher/actions/review_action_test.go
+++ b/internal/watcher/actions/review_action_test.go
@@ -43,7 +43,7 @@ func TestReviewAction_Execute(t *testing.T) {
 		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:review-requested", "status:reviewing").Return(nil)
 
 		// tmuxウィンドウへの切り替え
-		mockTmux.On("SwitchToIssueWindow", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "review").Return(nil)
 
 		// mainブランチの更新
 		mockWorktree.On("UpdateMainBranch", ctx).Return(nil)
@@ -65,7 +65,7 @@ func TestReviewAction_Execute(t *testing.T) {
 			IssueTitle:  "Test Issue",
 			RepoName:    "douhashi/osoba",
 		}
-		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "issue-28", workdir).Return(nil)
+		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "28-review", workdir).Return(nil)
 
 		// レビュー完了後のラベル追加
 		mockLabel.On("AddLabel", ctx, int(issueNumber), "status:completed").Return(nil)
@@ -117,7 +117,7 @@ func TestReviewAction_Execute(t *testing.T) {
 
 		// Assert
 		assert.NoError(t, err) // 処理済みはエラーではない
-		mockTmux.AssertNotCalled(t, "SwitchToIssueWindow")
+		mockTmux.AssertNotCalled(t, "CreateWindowForIssue")
 		mockLabel.AssertNotCalled(t, "TransitionLabel")
 		mockWorktree.AssertNotCalled(t, "UpdateMainBranch")
 		mockClaude.AssertNotCalled(t, "ExecuteInTmux")
@@ -165,7 +165,7 @@ func TestReviewAction_Execute(t *testing.T) {
 		// Assert
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "transition label")
-		mockTmux.AssertNotCalled(t, "SwitchToIssueWindow")
+		mockTmux.AssertNotCalled(t, "CreateWindowForIssue")
 		mockWorktree.AssertNotCalled(t, "UpdateMainBranch")
 		mockClaude.AssertNotCalled(t, "ExecuteInTmux")
 		mockState.AssertExpectations(t)
@@ -203,7 +203,7 @@ func TestReviewAction_Execute(t *testing.T) {
 		mockLabel.On("TransitionLabel", ctx, int(issueNumber), "status:review-requested", "status:reviewing").Return(nil)
 
 		// tmuxウィンドウへの切り替え
-		mockTmux.On("SwitchToIssueWindow", sessionName, int(issueNumber)).Return(nil)
+		mockTmux.On("CreateWindowForIssue", sessionName, int(issueNumber), "review").Return(nil)
 
 		// mainブランチの更新
 		mockWorktree.On("UpdateMainBranch", ctx).Return(nil)
@@ -225,7 +225,7 @@ func TestReviewAction_Execute(t *testing.T) {
 			IssueTitle:  "Test Issue",
 			RepoName:    "douhashi/osoba",
 		}
-		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "issue-28", workdir).Return(assert.AnError)
+		mockClaude.On("ExecuteInTmux", ctx, phaseConfig, templateVars, sessionName, "28-review", workdir).Return(assert.AnError)
 
 		// 処理失敗
 		mockState.On("MarkAsFailed", issueNumber, types.IssueStateReview)


### PR DESCRIPTION
## 概要
tmuxウィンドウの命名をフェーズ別に対応させる修正

## 関連するIssue
ユーザーのフィードバックで、tmuxウィンドウが `issue-33` 形式で作成されているが、期待値は `33-plan`、`33-implement`、`33-review` のようにフェーズ別のウィンドウが作成されることが判明したため修正。

## 変更内容
- `CreateWindowForIssueWithExecutor` 関数を追加してフェーズパラメータに対応
- `SwitchToIssueWindowWithExecutor` 関数を追加してフェーズパラメータに対応
- `TmuxClient` インターフェースにフェーズパラメータを追加
- 各アクション（plan/implement/review）でフェーズ別ウィンドウを作成するよう変更
- ウィンドウ名形式を `issue-{number}` から `{number}-{phase}` に変更
- 完全なテストカバレッジを追加

## 技術的な詳細

### フェーズ別ウィンドウ作成
```go
// 従来: issue-33
// 新しい: 33-plan, 33-implement, 33-review
func CreateWindowForIssueWithExecutor(sessionName string, issueNumber int, phase string, executor CommandExecutor) error
func SwitchToIssueWindowWithExecutor(sessionName string, issueNumber int, phase string, executor CommandExecutor) error
```

### TmuxClient インターフェース更新
```go
type TmuxClient interface {
    CreateWindowForIssue(sessionName string, issueNumber int, phase string) error
    SwitchToIssueWindow(sessionName string, issueNumber int, phase string) error
    WindowExists(sessionName, windowName string) (bool, error)
}
```

### アクション別の実装
- **PlanAction**: `33-plan` ウィンドウを作成
- **ImplementationAction**: `33-implement` ウィンドウを作成
- **ReviewAction**: `33-review` ウィンドウを作成

## テスト結果
- [x] 新しいフェーズ別ウィンドウ作成のテストを追加
- [x] 全てのアクションテストが正常に通過
- [x] 内部パッケージ全体のテストが正常に通過
- [x] TDD手法で実装（Red-Green-Refactor）

## 影響範囲
- tmux ウィンドウ管理機能
- 各アクション（plan/implement/review）の実行
- 既存のテストファイル

## 破壊的変更
- 後方互換性は不要との確認済み
- ウィンドウ名の形式変更により既存のtmuxセッションでは新しい形式で作成される

## レビューポイント
- フェーズ別ウィンドウの命名規則が正しく実装されているか
- TmuxClientインターフェースの変更が適切に反映されているか
- テストカバレッジが十分であるか
EOF < /dev/null