### PR TITLE
fix: osoba status/openコマンドで設定ファイルが読み込まれない問題を修正

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,20 @@ func Execute() {
 
 func initConfig() error {
 	if cfgFile != "" {
+		// ファイルの存在を確認
+		if _, err := os.Stat(cfgFile); err != nil {
+			// ファイルが存在しない場合は、エラーを返さずにデフォルト値を使用
+			if os.IsNotExist(err) {
+				// 設定ファイルが見つからない場合はデフォルト値を使用
+				viper.SetDefault("github.poll_interval", "5s")
+				viper.SetDefault("github.labels.plan", "status:needs-plan")
+				viper.SetDefault("github.labels.ready", "status:ready")
+				viper.SetDefault("github.labels.review", "status:review-requested")
+				viper.SetDefault("tmux.session_prefix", "osoba-")
+				return nil
+			}
+			return fmt.Errorf("failed to access config file: %w", err)
+		}
 		viper.SetConfigFile(cfgFile)
 	} else {
 		home, err := os.UserHomeDir()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -37,9 +37,20 @@ func runStatusCmd(cmd *cobra.Command) error {
 
 	// 設定を読み込み
 	cfg := config.NewConfig()
-	configPath := viper.GetString("config")
+
+	// rootコマンドで読み込まれた設定ファイルのパスを取得
+	configPath := viper.ConfigFileUsed()
+	if configPath == "" {
+		// -cフラグが指定されている場合はそれを使用
+		configPath = viper.GetString("config")
+	}
+
+	// 設定ファイルのパスが取得できた場合、またはデフォルトパスから読み込み
 	if configPath != "" {
 		cfg.LoadOrDefault(configPath)
+	} else {
+		// configPathが空の場合もデフォルト設定ファイルをチェック
+		cfg.LoadOrDefault("")
 	}
 
 	// tmuxがインストールされているかチェック

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -317,3 +317,154 @@ func TestDisplayConfigurationEnvironmentVariables(t *testing.T) {
 	t.Skip("環境変数テストは複雑なため一時的にスキップ")
 	// このテストは環境変数の管理が複雑なため、実際の動作確認は手動で行う
 }
+
+func TestStatusCmdConfigFileLoading(t *testing.T) {
+	tests := []struct {
+		name                 string
+		configContent        string
+		configPath           string
+		configFlag           string
+		expectedPollInterval string
+		expectedPrefix       string
+	}{
+		{
+			name: "デフォルトパスから設定ファイルを読み込み",
+			configContent: `
+github:
+  poll_interval: "10s"
+tmux:
+  session_prefix: "test-"
+`,
+			expectedPollInterval: "10s",
+			expectedPrefix:       "test-",
+		},
+		{
+			name: "-cフラグで別の設定ファイルを指定",
+			configContent: `
+github:
+  poll_interval: "20s"
+tmux:
+  session_prefix: "custom-"
+`,
+			configFlag:           "custom.yml",
+			expectedPollInterval: "20s",
+			expectedPrefix:       "custom-",
+		},
+		{
+			name:                 "設定ファイルが存在しない場合のデフォルト値",
+			configPath:           "/nonexistent/path/osoba.yml", // 存在しないパスを明示的に指定
+			configFlag:           "/nonexistent/path/osoba.yml",
+			expectedPollInterval: "5s",     // デフォルト値
+			expectedPrefix:       "osoba-", // デフォルト値
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 環境変数をクリア
+			originalGitHubToken := os.Getenv("GITHUB_TOKEN")
+			originalOsobaGitHubToken := os.Getenv("OSOBA_GITHUB_TOKEN")
+			defer func() {
+				if originalGitHubToken != "" {
+					os.Setenv("GITHUB_TOKEN", originalGitHubToken)
+				} else {
+					os.Unsetenv("GITHUB_TOKEN")
+				}
+				if originalOsobaGitHubToken != "" {
+					os.Setenv("OSOBA_GITHUB_TOKEN", originalOsobaGitHubToken)
+				} else {
+					os.Unsetenv("OSOBA_GITHUB_TOKEN")
+				}
+			}()
+			os.Unsetenv("GITHUB_TOKEN")
+			os.Unsetenv("OSOBA_GITHUB_TOKEN")
+
+			// viperをリセット
+			viper.Reset()
+			// cfgFileグローバル変数をクリア
+			cfgFile = ""
+
+			var args []string
+
+			if tt.configContent != "" {
+				// 一時ディレクトリを作成
+				tmpDir := t.TempDir()
+
+				if tt.configFlag != "" {
+					// -cフラグでカスタムパスを指定
+					configPath := filepath.Join(tmpDir, tt.configFlag)
+					err := os.WriteFile(configPath, []byte(tt.configContent), 0644)
+					if err != nil {
+						t.Fatalf("設定ファイル作成失敗: %v", err)
+					}
+					args = []string{"status", "-c", configPath}
+				} else {
+					// デフォルトパスに設定ファイルを配置
+					configDir := filepath.Join(tmpDir, ".config", "osoba")
+					err := os.MkdirAll(configDir, 0755)
+					if err != nil {
+						t.Fatalf("設定ディレクトリ作成失敗: %v", err)
+					}
+					configPath := filepath.Join(configDir, "osoba.yml")
+					err = os.WriteFile(configPath, []byte(tt.configContent), 0644)
+					if err != nil {
+						t.Fatalf("設定ファイル作成失敗: %v", err)
+					}
+					// HOMEを一時ディレクトリに設定
+					originalHome := os.Getenv("HOME")
+					os.Setenv("HOME", tmpDir)
+					defer func() {
+						if originalHome != "" {
+							os.Setenv("HOME", originalHome)
+						} else {
+							os.Unsetenv("HOME")
+						}
+					}()
+					args = []string{"status"}
+				}
+			} else {
+				// configFlagが指定されていて、configContentが空の場合
+				if tt.configFlag != "" {
+					args = []string{"status", "-c", tt.configFlag}
+				} else {
+					// HOMEを一時ディレクトリに設定（既存の設定ファイルを回避）
+					tmpDir := t.TempDir()
+					originalHome := os.Getenv("HOME")
+					os.Setenv("HOME", tmpDir)
+					defer func() {
+						if originalHome != "" {
+							os.Setenv("HOME", originalHome)
+						} else {
+							os.Unsetenv("HOME")
+						}
+					}()
+					args = []string{"status"}
+				}
+			}
+
+			buf := new(bytes.Buffer)
+
+			rootCmd = newRootCmd()
+			rootCmd.AddCommand(newStatusCmd())
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs(args)
+
+			err := rootCmd.Execute()
+			if err != nil {
+				t.Errorf("Execute() error = %v", err)
+				return
+			}
+
+			output := buf.String()
+
+			// 設定値が正しく表示されているか確認
+			if !strings.Contains(output, "Poll Interval: "+tt.expectedPollInterval) {
+				t.Errorf("期待するPoll Intervalが見つかりません: '%s'\n実際の出力:\n%s", tt.expectedPollInterval, output)
+			}
+			if !strings.Contains(output, "Session Prefix: "+tt.expectedPrefix) {
+				t.Errorf("期待するSession Prefixが見つかりません: '%s'\n実際の出力:\n%s", tt.expectedPrefix, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
`osoba status`および`osoba open`コマンドで設定ファイル（~/.config/osoba/osoba.yml）が正しく読み込まれない問題を修正しました。

## 関連するIssue
fixes #81

## 変更内容
- cmd/status.goの設定読み込みロジックを改善
  - `viper.ConfigFileUsed()`を使用してrootコマンドで読み込まれた設定ファイルパスを取得
  - 設定ファイルが存在しない場合のデフォルト値処理を追加
- cmd/open.goも同様に設定ファイルを読み込むように修正
  - セッション名生成時に設定から`SessionPrefix`を使用
- cmd/root.goのinitConfig()を改善
  - 設定ファイルが見つからない場合はデフォルト値を使用
- internal/config/config.goのLoadOrDefault()メソッドを改善
  - 複数のデフォルトパスを試すように変更

## テスト結果
- [x] ユニットテスト実行済み（全てパス）
- [x] 設定ファイルの読み込みテストを追加（TDD）
- [x] go fmt実行済み

## テストケース
以下のケースでテストを実装：
1. デフォルトパスから設定ファイルを読み込み
2. `-c`フラグで別の設定ファイルを指定
3. 設定ファイルが存在しない場合のデフォルト値使用

## レビューポイント
- 設定ファイルの読み込みロジックが適切か
- エラーハンドリングが適切か
- 他のサブコマンドで同様の修正が必要ないか