### PR TITLE
feat: ログレベル管理システムの実装

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -103,6 +103,19 @@ func TestGlobalFlags(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "log-level フラグ",
+			args: []string{"--log-level", "debug"},
+			checkFunc: func(t *testing.T) {
+				val, err := rootCmd.Flags().GetString("log-level")
+				if err != nil {
+					t.Errorf("Failed to get log-level flag: %v", err)
+				}
+				if val != "debug" {
+					t.Errorf("log-level flag = %v, want debug", val)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -120,6 +133,71 @@ func TestGlobalFlags(t *testing.T) {
 
 			// チェック関数実行
 			tt.checkFunc(t)
+		})
+	}
+}
+
+func TestLogLevelFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantLogLevel string
+		wantErr      bool
+	}{
+		{
+			name:         "正常系: debug レベル",
+			args:         []string{"--log-level", "debug"},
+			wantLogLevel: "debug",
+			wantErr:      false,
+		},
+		{
+			name:         "正常系: info レベル",
+			args:         []string{"--log-level", "info"},
+			wantLogLevel: "info",
+			wantErr:      false,
+		},
+		{
+			name:         "正常系: warn レベル",
+			args:         []string{"--log-level", "warn"},
+			wantLogLevel: "warn",
+			wantErr:      false,
+		},
+		{
+			name:         "正常系: error レベル",
+			args:         []string{"--log-level", "error"},
+			wantLogLevel: "error",
+			wantErr:      false,
+		},
+		{
+			name:         "正常系: 短縮形 -l",
+			args:         []string{"-l", "debug"},
+			wantLogLevel: "debug",
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// テスト用のルートコマンドを作成
+			rootCmd = newRootCmd()
+			rootCmd.SetArgs(tt.args)
+
+			// フラグのパース
+			err := rootCmd.ParseFlags(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				val, err := rootCmd.Flags().GetString("log-level")
+				if err != nil {
+					t.Errorf("Failed to get log-level flag: %v", err)
+				}
+				if val != tt.wantLogLevel {
+					t.Errorf("log-level flag = %v, want %v", val, tt.wantLogLevel)
+				}
+			}
 		})
 	}
 }

--- a/internal/git/command.go
+++ b/internal/git/command.go
@@ -33,8 +33,8 @@ func (c *Command) Run(ctx context.Context, command string, args []string, workDi
 		logFields = append(logFields, "workDir", workDir)
 	}
 
-	// コマンド実行開始をログ出力
-	c.logger.Info("Executing git command", logFields...)
+	// コマンド実行開始をログ出力（DEBUGレベルに変更）
+	c.logger.Debug("Executing git command", logFields...)
 
 	// コマンドを作成
 	cmd := exec.CommandContext(ctx, command, args...)
@@ -87,7 +87,7 @@ func (c *Command) Run(ctx context.Context, command string, args []string, workDi
 		successFields = append(successFields, "stderr", truncateOutput(stderrStr, 500))
 	}
 
-	c.logger.Info("Git command completed successfully", successFields...)
+	c.logger.Debug("Git command completed successfully", successFields...)
 
 	// 標準出力を返す
 	return stdoutStr, nil

--- a/internal/git/command_test.go
+++ b/internal/git/command_test.go
@@ -72,8 +72,8 @@ func TestCommand_Run(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// ログ出力をキャプチャするための設定
-			core, recorded := observer.New(zapcore.InfoLevel)
+			// ログ出力をキャプチャするための設定（DEBUGレベル）
+			core, recorded := observer.New(zapcore.DebugLevel)
 			testLogger := &testLoggerImpl{
 				sugar: zap.New(core).Sugar(),
 			}


### PR DESCRIPTION
## 概要
GitHub Issue #99で要求されたログレベル管理システムを実装しました。

## 実装内容
- DEBUG/INFO/WARN/ERRORの4つのログレベルを定義
- 設定ファイル(config.yaml)でデフォルトのログレベルを設定可能
- コマンドラインオプション(--log-level, -l)でログレベルを動的に変更可能
- 環境変数(OSOBA_LOG_LEVEL)でのログレベル設定
- gitコマンドの実行ログをINFOレベルからDEBUGレベルに変更
- 既存のloggerパッケージと統合したログレベル管理機能を実装

## 変更ファイル
- `internal/config/config.go`: ログレベル設定の追加
- `internal/config/config_test.go`: ログレベル設定のテスト追加
- `cmd/root.go`: --log-levelオプションの追加
- `cmd/root_test.go`: CLIオプションのテスト追加
- `internal/git/command.go`: ログレベルをINFOからDEBUGに変更
- `internal/git/command_test.go`: テストのログレベル修正

## 使用方法
### 設定ファイル
```yaml
log:
  level: debug
  format: text
```

### コマンドライン
```bash
osoba --log-level debug start
osoba -l warn status
```

### 環境変数
```bash
export OSOBA_LOG_LEVEL=debug
osoba start
```

## テスト結果
全てのテストがパスしています。

closes #99

🤖 Generated with [Claude Code](https://claude.ai/code)