### PR TITLE
feat: ラベル遷移の堅牢性向上とエラーハンドリング強化

### DIFF
--- a/internal/github/error_parser.go
+++ b/internal/github/error_parser.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	// Regular expressions for parsing gh command errors
+	rateLimitRegex   = regexp.MustCompile(`(?i)(rate limit|API rate limit exceeded|You have exceeded a secondary rate limit)`)
+	notFoundRegex    = regexp.MustCompile(`(?i)(not found|could not resolve to|does not have the label)`)
+	authRegex        = regexp.MustCompile(`(?i)(authentication|unauthorized|bad credentials|requires authentication|owner is required)`)
+	networkRegex     = regexp.MustCompile(`(?i)(timeout|connection refused|network|dial tcp)`)
+	serverErrorRegex = regexp.MustCompile(`(?i)(internal server error|server error|502|503|504)`)
+	httpStatusRegex  = regexp.MustCompile(`HTTP (\d{3})`)
+	retryAfterRegex  = regexp.MustCompile(`(?i)retry.?after:\s*(\d+)`)
+)
+
+// ParseGHError parses error output from gh command and returns a structured GitHubError
+func ParseGHError(errOutput string, err error) *GitHubError {
+	ghErr := &GitHubError{
+		Message:     strings.TrimSpace(errOutput),
+		OriginalErr: err,
+	}
+
+	// Extract HTTP status code if present
+	if matches := httpStatusRegex.FindStringSubmatch(errOutput); len(matches) > 1 {
+		if statusCode, err := strconv.Atoi(matches[1]); err == nil {
+			ghErr.StatusCode = statusCode
+		}
+	}
+
+	// Determine error type based on content
+	switch {
+	case rateLimitRegex.MatchString(errOutput):
+		ghErr.Type = ErrorTypeRateLimit
+		if ghErr.StatusCode == 0 {
+			ghErr.StatusCode = 429
+		}
+		// Try to extract retry-after duration
+		if matches := retryAfterRegex.FindStringSubmatch(errOutput); len(matches) > 1 {
+			if seconds, err := strconv.Atoi(matches[1]); err == nil {
+				ghErr.RetryAfter = time.Duration(seconds) * time.Second
+			}
+		}
+
+	case authRegex.MatchString(errOutput):
+		ghErr.Type = ErrorTypeAuthentication
+		if ghErr.StatusCode == 0 {
+			ghErr.StatusCode = 401
+		}
+
+	case notFoundRegex.MatchString(errOutput):
+		ghErr.Type = ErrorTypeNotFound
+		if ghErr.StatusCode == 0 {
+			ghErr.StatusCode = 404
+		}
+
+	case networkRegex.MatchString(errOutput):
+		ghErr.Type = ErrorTypeNetworkTimeout
+
+	case serverErrorRegex.MatchString(errOutput):
+		ghErr.Type = ErrorTypeServerError
+		if ghErr.StatusCode == 0 && strings.Contains(errOutput, "502") {
+			ghErr.StatusCode = 502
+		} else if ghErr.StatusCode == 0 && strings.Contains(errOutput, "503") {
+			ghErr.StatusCode = 503
+		} else if ghErr.StatusCode == 0 && strings.Contains(errOutput, "504") {
+			ghErr.StatusCode = 504
+		} else if ghErr.StatusCode == 0 {
+			ghErr.StatusCode = 500
+		}
+
+	default:
+		ghErr.Type = ErrorTypeUnknown
+		// Check if it's a 5xx error based on status code
+		if ghErr.StatusCode >= 500 && ghErr.StatusCode < 600 {
+			ghErr.Type = ErrorTypeServerError
+		}
+	}
+
+	return ghErr
+}
+
+// ClassifyError takes an error and attempts to classify it as a GitHubError
+func ClassifyError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// If it's already a GitHubError, return as is
+	var ghErr *GitHubError
+	if errors.As(err, &ghErr) {
+		return err
+	}
+
+	// Try to parse the error message
+	errMsg := err.Error()
+	return ParseGHError(errMsg, err)
+}
+
+// WrapWithRetryInfo wraps an error with retry information
+func WrapWithRetryInfo(err error, retryAfter time.Duration) error {
+	if err == nil {
+		return nil
+	}
+
+	ghErr, ok := err.(*GitHubError)
+	if !ok {
+		// Create a new GitHubError
+		ghErr = &GitHubError{
+			Type:        ErrorTypeUnknown,
+			Message:     err.Error(),
+			OriginalErr: err,
+		}
+	}
+
+	ghErr.RetryAfter = retryAfter
+	return ghErr
+}

--- a/internal/github/error_parser_test.go
+++ b/internal/github/error_parser_test.go
@@ -1,0 +1,273 @@
+package github
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParseGHError(t *testing.T) {
+	tests := []struct {
+		name           string
+		errOutput      string
+		err            error
+		expectedType   GitHubErrorType
+		expectedStatus int
+		expectRetry    bool
+	}{
+		{
+			name:           "rate limit error",
+			errOutput:      "gh: API rate limit exceeded for user ID 12345",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeRateLimit,
+			expectedStatus: 429,
+			expectRetry:    false,
+		},
+		{
+			name:           "rate limit with retry after",
+			errOutput:      "gh: You have exceeded a secondary rate limit. Retry after: 60",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeRateLimit,
+			expectedStatus: 429,
+			expectRetry:    true,
+		},
+		{
+			name:           "not found error",
+			errOutput:      "gh: could not resolve to a Repository with the name 'owner/repo'",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeNotFound,
+			expectedStatus: 404,
+			expectRetry:    false,
+		},
+		{
+			name:           "label not found",
+			errOutput:      "gh: issue does not have the label 'status:ready'",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeNotFound,
+			expectedStatus: 404,
+			expectRetry:    false,
+		},
+		{
+			name:           "authentication error",
+			errOutput:      "gh: authentication required",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeAuthentication,
+			expectedStatus: 401,
+			expectRetry:    false,
+		},
+		{
+			name:           "owner is required error",
+			errOutput:      "owner is required",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeAuthentication,
+			expectedStatus: 401,
+			expectRetry:    false,
+		},
+		{
+			name:           "network timeout",
+			errOutput:      "dial tcp: lookup api.github.com: i/o timeout",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeNetworkTimeout,
+			expectedStatus: 0,
+			expectRetry:    false,
+		},
+		{
+			name:           "server error 500",
+			errOutput:      "gh: Internal Server Error (HTTP 500)",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeServerError,
+			expectedStatus: 500,
+			expectRetry:    false,
+		},
+		{
+			name:           "server error 502",
+			errOutput:      "gh: Bad Gateway (HTTP 502)",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeServerError,
+			expectedStatus: 502,
+			expectRetry:    false,
+		},
+		{
+			name:           "unknown error",
+			errOutput:      "some random error",
+			err:            errors.New("exit status 1"),
+			expectedType:   ErrorTypeUnknown,
+			expectedStatus: 0,
+			expectRetry:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghErr := ParseGHError(tt.errOutput, tt.err)
+
+			if ghErr.Type != tt.expectedType {
+				t.Errorf("ParseGHError() Type = %v, want %v", ghErr.Type, tt.expectedType)
+			}
+
+			if ghErr.StatusCode != tt.expectedStatus {
+				t.Errorf("ParseGHError() StatusCode = %v, want %v", ghErr.StatusCode, tt.expectedStatus)
+			}
+
+			if tt.expectRetry && ghErr.RetryAfter == 0 {
+				t.Errorf("ParseGHError() expected RetryAfter to be set")
+			}
+
+			if ghErr.OriginalErr != tt.err {
+				t.Errorf("ParseGHError() OriginalErr = %v, want %v", ghErr.OriginalErr, tt.err)
+			}
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedType GitHubErrorType
+	}{
+		{
+			name:         "nil error",
+			err:          nil,
+			expectedType: ErrorTypeUnknown,
+		},
+		{
+			name: "already GitHubError",
+			err: &GitHubError{
+				Type:    ErrorTypeRateLimit,
+				Message: "rate limited",
+			},
+			expectedType: ErrorTypeRateLimit,
+		},
+		{
+			name:         "rate limit in error message",
+			err:          errors.New("API rate limit exceeded"),
+			expectedType: ErrorTypeRateLimit,
+		},
+		{
+			name:         "not found in error message",
+			err:          errors.New("repository not found"),
+			expectedType: ErrorTypeNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ClassifyError(tt.err)
+
+			if tt.err == nil {
+				if result != nil {
+					t.Errorf("ClassifyError() = %v, want nil", result)
+				}
+				return
+			}
+
+			ghErr, ok := result.(*GitHubError)
+			if !ok && tt.err != nil {
+				t.Errorf("ClassifyError() did not return *GitHubError")
+				return
+			}
+
+			if ghErr != nil && ghErr.Type != tt.expectedType {
+				t.Errorf("ClassifyError() Type = %v, want %v", ghErr.Type, tt.expectedType)
+			}
+		})
+	}
+}
+
+func TestWrapWithRetryInfo(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		retryAfter    time.Duration
+		expectWrapped bool
+	}{
+		{
+			name:          "nil error",
+			err:           nil,
+			retryAfter:    60 * time.Second,
+			expectWrapped: false,
+		},
+		{
+			name:          "wrap plain error",
+			err:           errors.New("some error"),
+			retryAfter:    30 * time.Second,
+			expectWrapped: true,
+		},
+		{
+			name: "wrap existing GitHubError",
+			err: &GitHubError{
+				Type:    ErrorTypeServerError,
+				Message: "server error",
+			},
+			retryAfter:    45 * time.Second,
+			expectWrapped: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WrapWithRetryInfo(tt.err, tt.retryAfter)
+
+			if !tt.expectWrapped {
+				if result != nil {
+					t.Errorf("WrapWithRetryInfo() = %v, want nil", result)
+				}
+				return
+			}
+
+			ghErr, ok := result.(*GitHubError)
+			if !ok {
+				t.Errorf("WrapWithRetryInfo() did not return *GitHubError")
+				return
+			}
+
+			if ghErr.RetryAfter != tt.retryAfter {
+				t.Errorf("WrapWithRetryInfo() RetryAfter = %v, want %v", ghErr.RetryAfter, tt.retryAfter)
+			}
+		})
+	}
+}
+
+func TestErrorParsing_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		errOutput string
+		expected  GitHubErrorType
+	}{
+		{
+			name:      "mixed case rate limit",
+			errOutput: "GH: api RATE LIMIT Exceeded",
+			expected:  ErrorTypeRateLimit,
+		},
+		{
+			name:      "HTTP status in middle of text",
+			errOutput: "Error occurred HTTP 503 Service Unavailable",
+			expected:  ErrorTypeServerError,
+		},
+		{
+			name:      "multiple error indicators",
+			errOutput: "Authentication failed: rate limit exceeded",
+			expected:  ErrorTypeRateLimit, // Rate limit takes precedence
+		},
+		{
+			name:      "empty error output",
+			errOutput: "",
+			expected:  ErrorTypeUnknown,
+		},
+		{
+			name:      "whitespace only",
+			errOutput: "   \n\t   ",
+			expected:  ErrorTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghErr := ParseGHError(tt.errOutput, errors.New("test error"))
+			if ghErr.Type != tt.expected {
+				t.Errorf("ParseGHError() Type = %v, want %v", ghErr.Type, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// GitHubErrorType represents the type of GitHub API error
+type GitHubErrorType int
+
+const (
+	// ErrorTypeRateLimit indicates rate limit exceeded
+	ErrorTypeRateLimit GitHubErrorType = iota
+	// ErrorTypeNetworkTimeout indicates network timeout
+	ErrorTypeNetworkTimeout
+	// ErrorTypeAuthentication indicates authentication failure
+	ErrorTypeAuthentication
+	// ErrorTypeNotFound indicates resource not found
+	ErrorTypeNotFound
+	// ErrorTypeServerError indicates server error (5xx)
+	ErrorTypeServerError
+	// ErrorTypeUnknown indicates unknown error type
+	ErrorTypeUnknown
+)
+
+// String returns the string representation of the error type
+func (t GitHubErrorType) String() string {
+	switch t {
+	case ErrorTypeRateLimit:
+		return "RateLimit"
+	case ErrorTypeNetworkTimeout:
+		return "NetworkTimeout"
+	case ErrorTypeAuthentication:
+		return "Authentication"
+	case ErrorTypeNotFound:
+		return "NotFound"
+	case ErrorTypeServerError:
+		return "ServerError"
+	default:
+		return "Unknown"
+	}
+}
+
+// GitHubError represents a structured GitHub API error
+type GitHubError struct {
+	Type        GitHubErrorType
+	StatusCode  int
+	Message     string
+	RetryAfter  time.Duration
+	OriginalErr error
+}
+
+// Error implements the error interface
+func (e *GitHubError) Error() string {
+	if e.OriginalErr != nil {
+		return fmt.Sprintf("GitHub API error [%s]: %s (original: %v)", e.Type, e.Message, e.OriginalErr)
+	}
+	return fmt.Sprintf("GitHub API error [%s]: %s", e.Type, e.Message)
+}
+
+// Unwrap returns the original error
+func (e *GitHubError) Unwrap() error {
+	return e.OriginalErr
+}
+
+// IsRetryable returns true if the error is retryable
+func (e *GitHubError) IsRetryable() bool {
+	switch e.Type {
+	case ErrorTypeRateLimit, ErrorTypeNetworkTimeout, ErrorTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsRateLimitError checks if the error is a rate limit error
+func IsRateLimitError(err error) bool {
+	var ghErr *GitHubError
+	if errors.As(err, &ghErr) {
+		return ghErr.Type == ErrorTypeRateLimit
+	}
+	return false
+}
+
+// IsNotFoundError checks if the error is a not found error
+func IsNotFoundError(err error) bool {
+	var ghErr *GitHubError
+	if errors.As(err, &ghErr) {
+		return ghErr.Type == ErrorTypeNotFound
+	}
+	return false
+}
+
+// IsAuthenticationError checks if the error is an authentication error
+func IsAuthenticationError(err error) bool {
+	var ghErr *GitHubError
+	if errors.As(err, &ghErr) {
+		return ghErr.Type == ErrorTypeAuthentication
+	}
+	return false
+}

--- a/internal/github/errors_test.go
+++ b/internal/github/errors_test.go
@@ -1,0 +1,313 @@
+package github
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGitHubErrorType_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		errType  GitHubErrorType
+		expected string
+	}{
+		{
+			name:     "RateLimit",
+			errType:  ErrorTypeRateLimit,
+			expected: "RateLimit",
+		},
+		{
+			name:     "NetworkTimeout",
+			errType:  ErrorTypeNetworkTimeout,
+			expected: "NetworkTimeout",
+		},
+		{
+			name:     "Authentication",
+			errType:  ErrorTypeAuthentication,
+			expected: "Authentication",
+		},
+		{
+			name:     "NotFound",
+			errType:  ErrorTypeNotFound,
+			expected: "NotFound",
+		},
+		{
+			name:     "ServerError",
+			errType:  ErrorTypeServerError,
+			expected: "ServerError",
+		},
+		{
+			name:     "Unknown",
+			errType:  ErrorTypeUnknown,
+			expected: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.errType.String(); got != tt.expected {
+				t.Errorf("GitHubErrorType.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGitHubError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      GitHubError
+		expected string
+	}{
+		{
+			name: "with original error",
+			err: GitHubError{
+				Type:        ErrorTypeRateLimit,
+				StatusCode:  429,
+				Message:     "API rate limit exceeded",
+				OriginalErr: errors.New("original error"),
+			},
+			expected: "GitHub API error [RateLimit]: API rate limit exceeded (original: original error)",
+		},
+		{
+			name: "without original error",
+			err: GitHubError{
+				Type:       ErrorTypeNotFound,
+				StatusCode: 404,
+				Message:    "Resource not found",
+			},
+			expected: "GitHub API error [NotFound]: Resource not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.expected {
+				t.Errorf("GitHubError.Error() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGitHubError_Unwrap(t *testing.T) {
+	originalErr := errors.New("original error")
+	ghErr := &GitHubError{
+		Type:        ErrorTypeServerError,
+		StatusCode:  500,
+		Message:     "Internal server error",
+		OriginalErr: originalErr,
+	}
+
+	if got := ghErr.Unwrap(); got != originalErr {
+		t.Errorf("GitHubError.Unwrap() = %v, want %v", got, originalErr)
+	}
+}
+
+func TestGitHubError_IsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      GitHubError
+		expected bool
+	}{
+		{
+			name: "rate limit error is retryable",
+			err: GitHubError{
+				Type:       ErrorTypeRateLimit,
+				StatusCode: 429,
+			},
+			expected: true,
+		},
+		{
+			name: "network timeout is retryable",
+			err: GitHubError{
+				Type: ErrorTypeNetworkTimeout,
+			},
+			expected: true,
+		},
+		{
+			name: "server error is retryable",
+			err: GitHubError{
+				Type:       ErrorTypeServerError,
+				StatusCode: 500,
+			},
+			expected: true,
+		},
+		{
+			name: "not found error is not retryable",
+			err: GitHubError{
+				Type:       ErrorTypeNotFound,
+				StatusCode: 404,
+			},
+			expected: false,
+		},
+		{
+			name: "authentication error is not retryable",
+			err: GitHubError{
+				Type:       ErrorTypeAuthentication,
+				StatusCode: 401,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.IsRetryable(); got != tt.expected {
+				t.Errorf("GitHubError.IsRetryable() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsRateLimitError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "rate limit error",
+			err: &GitHubError{
+				Type:       ErrorTypeRateLimit,
+				StatusCode: 429,
+			},
+			expected: true,
+		},
+		{
+			name: "not rate limit error",
+			err: &GitHubError{
+				Type:       ErrorTypeNotFound,
+				StatusCode: 404,
+			},
+			expected: false,
+		},
+		{
+			name:     "non-GitHubError",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRateLimitError(tt.err); got != tt.expected {
+				t.Errorf("IsRateLimitError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "not found error",
+			err: &GitHubError{
+				Type:       ErrorTypeNotFound,
+				StatusCode: 404,
+			},
+			expected: true,
+		},
+		{
+			name: "not a not found error",
+			err: &GitHubError{
+				Type:       ErrorTypeRateLimit,
+				StatusCode: 429,
+			},
+			expected: false,
+		},
+		{
+			name:     "non-GitHubError",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFoundError(tt.err); got != tt.expected {
+				t.Errorf("IsNotFoundError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsAuthenticationError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "authentication error",
+			err: &GitHubError{
+				Type:       ErrorTypeAuthentication,
+				StatusCode: 401,
+			},
+			expected: true,
+		},
+		{
+			name: "not authentication error",
+			err: &GitHubError{
+				Type:       ErrorTypeServerError,
+				StatusCode: 500,
+			},
+			expected: false,
+		},
+		{
+			name:     "non-GitHubError",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAuthenticationError(tt.err); got != tt.expected {
+				t.Errorf("IsAuthenticationError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGitHubError_RetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      GitHubError
+		expected time.Duration
+	}{
+		{
+			name: "with retry after",
+			err: GitHubError{
+				Type:       ErrorTypeRateLimit,
+				StatusCode: 429,
+				RetryAfter: 60 * time.Second,
+			},
+			expected: 60 * time.Second,
+		},
+		{
+			name: "without retry after",
+			err: GitHubError{
+				Type:       ErrorTypeServerError,
+				StatusCode: 500,
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.RetryAfter; got != tt.expected {
+				t.Errorf("GitHubError.RetryAfter = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/github/retry_strategy.go
+++ b/internal/github/retry_strategy.go
@@ -1,0 +1,160 @@
+package github
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// RetryStrategy defines the retry behavior for GitHub API operations
+type RetryStrategy struct {
+	MaxAttempts  int
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	Multiplier   float64
+	Jitter       bool
+}
+
+// DefaultRetryStrategy returns a default retry strategy
+func DefaultRetryStrategy() RetryStrategy {
+	return RetryStrategy{
+		MaxAttempts:  3,
+		InitialDelay: 1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		Multiplier:   2.0,
+		Jitter:       true,
+	}
+}
+
+// RateLimitRetryStrategy returns a retry strategy optimized for rate limits
+func RateLimitRetryStrategy() RetryStrategy {
+	return RetryStrategy{
+		MaxAttempts:  5,
+		InitialDelay: 5 * time.Second,
+		MaxDelay:     5 * time.Minute,
+		Multiplier:   2.0,
+		Jitter:       false, // Use exact retry-after values when available
+	}
+}
+
+// NetworkRetryStrategy returns a retry strategy optimized for network issues
+func NetworkRetryStrategy() RetryStrategy {
+	return RetryStrategy{
+		MaxAttempts:  4,
+		InitialDelay: 500 * time.Millisecond,
+		MaxDelay:     10 * time.Second,
+		Multiplier:   1.5,
+		Jitter:       true,
+	}
+}
+
+// GetRetryDelay calculates the delay for a given attempt
+func (rs *RetryStrategy) GetRetryDelay(attempt int) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+
+	// Calculate exponential delay
+	delay := float64(rs.InitialDelay) * math.Pow(rs.Multiplier, float64(attempt-1))
+
+	// Cap at max delay
+	if delay > float64(rs.MaxDelay) {
+		delay = float64(rs.MaxDelay)
+	}
+
+	// Add jitter if enabled
+	if rs.Jitter && delay > 0 {
+		// Add up to 25% jitter
+		jitter := rand.Float64() * 0.25 * delay
+		delay += jitter
+	}
+
+	return time.Duration(delay)
+}
+
+// ShouldRetry determines if an operation should be retried based on the error
+func (rs *RetryStrategy) ShouldRetry(err error, attempt int) bool {
+	if err == nil || attempt >= rs.MaxAttempts {
+		return false
+	}
+
+	// Check if error is retryable
+	ghErr, ok := err.(*GitHubError)
+	if !ok {
+		// For non-GitHubError, retry on a limited basis
+		return attempt < 2
+	}
+
+	return ghErr.IsRetryable()
+}
+
+// GetStrategyForError returns the appropriate retry strategy for a given error
+func GetStrategyForError(err error) RetryStrategy {
+	ghErr, ok := err.(*GitHubError)
+	if !ok {
+		return DefaultRetryStrategy()
+	}
+
+	switch ghErr.Type {
+	case ErrorTypeRateLimit:
+		return RateLimitRetryStrategy()
+	case ErrorTypeNetworkTimeout:
+		return NetworkRetryStrategy()
+	case ErrorTypeServerError:
+		// Server errors get moderate retry
+		return RetryStrategy{
+			MaxAttempts:  3,
+			InitialDelay: 2 * time.Second,
+			MaxDelay:     20 * time.Second,
+			Multiplier:   2.0,
+			Jitter:       true,
+		}
+	default:
+		return DefaultRetryStrategy()
+	}
+}
+
+// RetryWithStrategy executes a function with retry logic
+func RetryWithStrategy(ctx context.Context, strategy RetryStrategy, operation func() error) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= strategy.MaxAttempts; attempt++ {
+		// Execute the operation
+		err := operation()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if we should retry
+		if !strategy.ShouldRetry(err, attempt) {
+			return err
+		}
+
+		// Check if context is cancelled
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Don't sleep on the last attempt
+		if attempt < strategy.MaxAttempts {
+			delay := strategy.GetRetryDelay(attempt)
+
+			// If error has specific retry-after, use it
+			if ghErr, ok := err.(*GitHubError); ok && ghErr.RetryAfter > 0 {
+				delay = ghErr.RetryAfter
+			}
+
+			select {
+			case <-time.After(delay):
+				// Continue to next attempt
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/internal/github/retry_strategy_test.go
+++ b/internal/github/retry_strategy_test.go
@@ -1,0 +1,440 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDefaultRetryStrategy(t *testing.T) {
+	rs := DefaultRetryStrategy()
+
+	if rs.MaxAttempts != 3 {
+		t.Errorf("DefaultRetryStrategy() MaxAttempts = %v, want 3", rs.MaxAttempts)
+	}
+	if rs.InitialDelay != 1*time.Second {
+		t.Errorf("DefaultRetryStrategy() InitialDelay = %v, want 1s", rs.InitialDelay)
+	}
+	if rs.MaxDelay != 30*time.Second {
+		t.Errorf("DefaultRetryStrategy() MaxDelay = %v, want 30s", rs.MaxDelay)
+	}
+	if rs.Multiplier != 2.0 {
+		t.Errorf("DefaultRetryStrategy() Multiplier = %v, want 2.0", rs.Multiplier)
+	}
+	if !rs.Jitter {
+		t.Errorf("DefaultRetryStrategy() Jitter = false, want true")
+	}
+}
+
+func TestRateLimitRetryStrategy(t *testing.T) {
+	rs := RateLimitRetryStrategy()
+
+	if rs.MaxAttempts != 5 {
+		t.Errorf("RateLimitRetryStrategy() MaxAttempts = %v, want 5", rs.MaxAttempts)
+	}
+	if rs.InitialDelay != 5*time.Second {
+		t.Errorf("RateLimitRetryStrategy() InitialDelay = %v, want 5s", rs.InitialDelay)
+	}
+	if rs.MaxDelay != 5*time.Minute {
+		t.Errorf("RateLimitRetryStrategy() MaxDelay = %v, want 5m", rs.MaxDelay)
+	}
+	if rs.Jitter {
+		t.Errorf("RateLimitRetryStrategy() Jitter = true, want false")
+	}
+}
+
+func TestNetworkRetryStrategy(t *testing.T) {
+	rs := NetworkRetryStrategy()
+
+	if rs.MaxAttempts != 4 {
+		t.Errorf("NetworkRetryStrategy() MaxAttempts = %v, want 4", rs.MaxAttempts)
+	}
+	if rs.InitialDelay != 500*time.Millisecond {
+		t.Errorf("NetworkRetryStrategy() InitialDelay = %v, want 500ms", rs.InitialDelay)
+	}
+	if rs.MaxDelay != 10*time.Second {
+		t.Errorf("NetworkRetryStrategy() MaxDelay = %v, want 10s", rs.MaxDelay)
+	}
+	if rs.Multiplier != 1.5 {
+		t.Errorf("NetworkRetryStrategy() Multiplier = %v, want 1.5", rs.Multiplier)
+	}
+}
+
+func TestRetryStrategy_GetRetryDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy RetryStrategy
+		attempt  int
+		minDelay time.Duration
+		maxDelay time.Duration
+	}{
+		{
+			name: "first attempt without jitter",
+			strategy: RetryStrategy{
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     10 * time.Second,
+				Multiplier:   2.0,
+				Jitter:       false,
+			},
+			attempt:  1,
+			minDelay: 1 * time.Second,
+			maxDelay: 1 * time.Second,
+		},
+		{
+			name: "second attempt without jitter",
+			strategy: RetryStrategy{
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     10 * time.Second,
+				Multiplier:   2.0,
+				Jitter:       false,
+			},
+			attempt:  2,
+			minDelay: 2 * time.Second,
+			maxDelay: 2 * time.Second,
+		},
+		{
+			name: "third attempt without jitter",
+			strategy: RetryStrategy{
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     10 * time.Second,
+				Multiplier:   2.0,
+				Jitter:       false,
+			},
+			attempt:  3,
+			minDelay: 4 * time.Second,
+			maxDelay: 4 * time.Second,
+		},
+		{
+			name: "with jitter",
+			strategy: RetryStrategy{
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     10 * time.Second,
+				Multiplier:   2.0,
+				Jitter:       true,
+			},
+			attempt:  2,
+			minDelay: 2 * time.Second,
+			maxDelay: 2500 * time.Millisecond, // 2s + 25% jitter
+		},
+		{
+			name: "capped at max delay",
+			strategy: RetryStrategy{
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     5 * time.Second,
+				Multiplier:   10.0,
+				Jitter:       false,
+			},
+			attempt:  3,
+			minDelay: 5 * time.Second,
+			maxDelay: 5 * time.Second,
+		},
+		{
+			name: "zero attempt",
+			strategy: RetryStrategy{
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     10 * time.Second,
+				Multiplier:   2.0,
+				Jitter:       false,
+			},
+			attempt:  0,
+			minDelay: 0,
+			maxDelay: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delay := tt.strategy.GetRetryDelay(tt.attempt)
+			if delay < tt.minDelay || delay > tt.maxDelay {
+				t.Errorf("GetRetryDelay() = %v, want between %v and %v", delay, tt.minDelay, tt.maxDelay)
+			}
+		})
+	}
+}
+
+func TestRetryStrategy_ShouldRetry(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy RetryStrategy
+		err      error
+		attempt  int
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			strategy: DefaultRetryStrategy(),
+			err:      nil,
+			attempt:  1,
+			expected: false,
+		},
+		{
+			name:     "exceeded max attempts",
+			strategy: RetryStrategy{MaxAttempts: 3},
+			err:      errors.New("some error"),
+			attempt:  3,
+			expected: false,
+		},
+		{
+			name:     "retryable GitHub error",
+			strategy: DefaultRetryStrategy(),
+			err: &GitHubError{
+				Type: ErrorTypeRateLimit,
+			},
+			attempt:  1,
+			expected: true,
+		},
+		{
+			name:     "non-retryable GitHub error",
+			strategy: DefaultRetryStrategy(),
+			err: &GitHubError{
+				Type: ErrorTypeNotFound,
+			},
+			attempt:  1,
+			expected: false,
+		},
+		{
+			name:     "non-GitHub error first attempt",
+			strategy: DefaultRetryStrategy(),
+			err:      errors.New("generic error"),
+			attempt:  1,
+			expected: true,
+		},
+		{
+			name:     "non-GitHub error second attempt",
+			strategy: DefaultRetryStrategy(),
+			err:      errors.New("generic error"),
+			attempt:  2,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.strategy.ShouldRetry(tt.err, tt.attempt); got != tt.expected {
+				t.Errorf("ShouldRetry() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetStrategyForError(t *testing.T) {
+	tests := []struct {
+		name                 string
+		err                  error
+		expectedMaxAttempts  int
+		expectedInitialDelay time.Duration
+	}{
+		{
+			name:                 "rate limit error",
+			err:                  &GitHubError{Type: ErrorTypeRateLimit},
+			expectedMaxAttempts:  5,
+			expectedInitialDelay: 5 * time.Second,
+		},
+		{
+			name:                 "network timeout error",
+			err:                  &GitHubError{Type: ErrorTypeNetworkTimeout},
+			expectedMaxAttempts:  4,
+			expectedInitialDelay: 500 * time.Millisecond,
+		},
+		{
+			name:                 "server error",
+			err:                  &GitHubError{Type: ErrorTypeServerError},
+			expectedMaxAttempts:  3,
+			expectedInitialDelay: 2 * time.Second,
+		},
+		{
+			name:                 "unknown error",
+			err:                  &GitHubError{Type: ErrorTypeUnknown},
+			expectedMaxAttempts:  3,
+			expectedInitialDelay: 1 * time.Second,
+		},
+		{
+			name:                 "non-GitHub error",
+			err:                  errors.New("generic error"),
+			expectedMaxAttempts:  3,
+			expectedInitialDelay: 1 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strategy := GetStrategyForError(tt.err)
+			if strategy.MaxAttempts != tt.expectedMaxAttempts {
+				t.Errorf("GetStrategyForError() MaxAttempts = %v, want %v", strategy.MaxAttempts, tt.expectedMaxAttempts)
+			}
+			if strategy.InitialDelay != tt.expectedInitialDelay {
+				t.Errorf("GetStrategyForError() InitialDelay = %v, want %v", strategy.InitialDelay, tt.expectedInitialDelay)
+			}
+		})
+	}
+}
+
+func TestRetryWithStrategy(t *testing.T) {
+	tests := []struct {
+		name           string
+		strategy       RetryStrategy
+		expectedCalls  int
+		expectError    bool
+		setupOperation func() (func() error, func() int)
+	}{
+		{
+			name: "success on first attempt",
+			strategy: RetryStrategy{
+				MaxAttempts:  3,
+				InitialDelay: 10 * time.Millisecond,
+			},
+			expectedCalls: 1,
+			expectError:   false,
+			setupOperation: func() (func() error, func() int) {
+				count := 0
+				return func() error {
+					count++
+					if count == 1 {
+						return nil
+					}
+					return errors.New("should not reach here")
+				}, func() int { return count }
+			},
+		},
+		{
+			name: "success on second attempt",
+			strategy: RetryStrategy{
+				MaxAttempts:  3,
+				InitialDelay: 10 * time.Millisecond,
+			},
+			expectedCalls: 2,
+			expectError:   false,
+			setupOperation: func() (func() error, func() int) {
+				count := 0
+				return func() error {
+					count++
+					if count == 2 {
+						return nil
+					}
+					return &GitHubError{Type: ErrorTypeServerError}
+				}, func() int { return count }
+			},
+		},
+		{
+			name: "all attempts fail",
+			strategy: RetryStrategy{
+				MaxAttempts:  3,
+				InitialDelay: 10 * time.Millisecond,
+			},
+			expectedCalls: 3,
+			expectError:   true,
+			setupOperation: func() (func() error, func() int) {
+				count := 0
+				return func() error {
+					count++
+					return &GitHubError{Type: ErrorTypeServerError}
+				}, func() int { return count }
+			},
+		},
+		{
+			name: "non-retryable error",
+			strategy: RetryStrategy{
+				MaxAttempts:  3,
+				InitialDelay: 10 * time.Millisecond,
+			},
+			expectedCalls: 1,
+			expectError:   true,
+			setupOperation: func() (func() error, func() int) {
+				count := 0
+				return func() error {
+					count++
+					return &GitHubError{Type: ErrorTypeNotFound}
+				}, func() int { return count }
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			operation, getCount := tt.setupOperation()
+
+			err := RetryWithStrategy(ctx, tt.strategy, operation)
+
+			// Get actual call count
+			callCount := getCount()
+
+			if (err != nil) != tt.expectError {
+				t.Errorf("RetryWithStrategy() error = %v, expectError = %v", err, tt.expectError)
+			}
+
+			if callCount != tt.expectedCalls {
+				t.Errorf("RetryWithStrategy() callCount = %v, want %v", callCount, tt.expectedCalls)
+			}
+		})
+	}
+}
+
+func TestRetryWithStrategy_ContextCancellation(t *testing.T) {
+	strategy := RetryStrategy{
+		MaxAttempts:  5,
+		InitialDelay: 1 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	callCount := 0
+	operation := func() error {
+		callCount++
+		if callCount == 2 {
+			cancel() // Cancel context on second attempt
+		}
+		return &GitHubError{Type: ErrorTypeServerError}
+	}
+
+	err := RetryWithStrategy(ctx, strategy, operation)
+
+	if err != context.Canceled {
+		t.Errorf("RetryWithStrategy() with cancelled context = %v, want context.Canceled", err)
+	}
+
+	// Should have attempted twice before cancellation
+	if callCount != 2 {
+		t.Errorf("RetryWithStrategy() callCount = %v, want 2", callCount)
+	}
+}
+
+func TestRetryWithStrategy_RespectRetryAfter(t *testing.T) {
+	strategy := RetryStrategy{
+		MaxAttempts:  2,
+		InitialDelay: 100 * time.Millisecond,
+	}
+
+	retryAfter := 50 * time.Millisecond
+	callCount := 0
+	start := time.Now()
+
+	operation := func() error {
+		callCount++
+		if callCount == 1 {
+			return &GitHubError{
+				Type:       ErrorTypeRateLimit,
+				RetryAfter: retryAfter,
+			}
+		}
+		return nil
+	}
+
+	err := RetryWithStrategy(context.Background(), strategy, operation)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("RetryWithStrategy() error = %v, want nil", err)
+	}
+
+	// Should have waited at least retryAfter duration
+	if elapsed < retryAfter {
+		t.Errorf("RetryWithStrategy() elapsed = %v, want at least %v", elapsed, retryAfter)
+	}
+
+	// But not too much longer (allowing some overhead)
+	if elapsed > retryAfter+20*time.Millisecond {
+		t.Errorf("RetryWithStrategy() elapsed = %v, want close to %v", elapsed, retryAfter)
+	}
+}


### PR DESCRIPTION
## 概要
GitHub APIのラベル遷移機能の堅牢性を向上させ、エラーハンドリングと自動リトライ機能を強化しました。

## 関連するIssue
fixes #108

## 変更内容

### 1. エラーハンドリングの強化
- **エラー分類システム**: GitHub APIエラーを6つのタイプ（RateLimit, NetworkTimeout, Authentication, NotFound, ServerError, Unknown）に分類
- **エラーパーサー**: ghコマンドの出力を解析して構造化されたエラーに変換
- **リトライ可否の自動判定**: エラータイプに基づいてリトライの可否を自動判定

### 2. 高度なリトライメカニズム
- **動的リトライ戦略**: エラータイプごとに最適化されたリトライ設定
  - Rate limitエラー: 最大5回、初回5秒待機
  - ネットワークエラー: 最大4回、初回500ms待機
  - サーバーエラー: 最大3回、初回2秒待機
- **指数バックオフとジッター**: リトライ間隔の効率的な制御
- **Rate limit対応**: retry-afterヘッダーの自動読み取りと適用

### 3. ロギングの改善
- エラータイプ、HTTPステータスコード、リトライ可否の詳細ログ
- リトライ戦略の詳細（最大試行回数、初回待機時間）の記録
- 問題診断とデバッグの容易化

## 新規ファイル
- `internal/github/errors.go`: GitHubエラーの構造定義
- `internal/github/error_parser.go`: エラー解析ロジック
- `internal/github/retry_strategy.go`: リトライ戦略の実装
- 各ファイルに対応するテストファイル

## 修正ファイル
- `internal/github/label_manager.go`: エラーハンドリングとリトライロジックの改善

## テスト結果
- [x] 全ての新規テストがパス
- [x] 既存のテストへの影響なし
- [x] go test ./... の実行に成功

## 影響範囲
- ラベル遷移機能の安定性が向上
- GitHub APIの一時的な障害に対する耐性が改善
- 既存のインターフェースに変更なし（後方互換性を維持）

## レビューポイント
1. エラー分類の妥当性（6つのタイプで十分か）
2. リトライ戦略のデフォルト値の適切さ
3. ログ出力の詳細度（デバッグに必要十分か）

## 今後の拡張
この実装を基盤として、以下の機能拡張が可能になりました：
- Phase 3: 状態管理と永続化
- Phase 4: 監視とアラート機能
- Phase 5: 手動復旧コマンド

## スクリーンショット
該当なし（バックエンド機能の改善のため）