### PR TITLE
feat: internal/claudeパッケージの統一ログシステムへの移行

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -174,10 +174,10 @@ func runWatchWithFlags(cmd *cobra.Command, args []string, intervalFlag, configFl
 	if claudeConfig == nil {
 		claudeConfig = claude.NewDefaultClaudeConfig()
 	}
-	claudeExecutor := claude.NewClaudeExecutor()
+	claudeExecutor := claude.NewClaudeExecutorWithLogger(appLogger)
 
 	// ActionFactoryを作成
-	actionFactory := watcher.NewDefaultActionFactory(
+	actionFactory := watcher.NewDefaultActionFactoryWithLogger(
 		sessionName,
 		githubClient,
 		worktreeManager,
@@ -186,6 +186,7 @@ func runWatchWithFlags(cmd *cobra.Command, args []string, intervalFlag, configFl
 		cfg,
 		owner,
 		repoName,
+		appLogger,
 	)
 
 	// Issue監視を作成

--- a/internal/claude/executor_masking_test.go
+++ b/internal/claude/executor_masking_test.go
@@ -1,0 +1,70 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskSensitiveData(t *testing.T) {
+	executor := &DefaultClaudeExecutor{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "GitHubトークンのマスキング - ghp_形式",
+			input:    "Token: ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+			expected: "Token: [GITHUB_TOKEN]",
+		},
+		{
+			name:     "GitHubトークンのマスキング - github_pat_形式",
+			input:    "PAT: github_pat_11AAAAAAA_abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNO",
+			expected: "PAT: [GITHUB_TOKEN]",
+		},
+		{
+			name:     "GitHubトークンのマスキング - ghs_形式",
+			input:    "Secret: ghs_1234567890abcdefghijklmnopqrstuvwxyz",
+			expected: "Secret: [GITHUB_TOKEN]",
+		},
+		{
+			name:     "APIキーのマスキング - sk-proj形式",
+			input:    "API Key: sk-proj-1234567890abcdefghijklmnopqrstuvwxyz1234567890AB",
+			expected: "API Key: [API_KEY]",
+		},
+		{
+			name:     "一般的なAPIキーのマスキング - api_key=形式",
+			input:    "Request with api_key=abcdefghijklmnopqrst1234567890",
+			expected: "Request with api_key=[MASKED]",
+		},
+		{
+			name:     "一般的なAPIキーのマスキング - apiKey:形式",
+			input:    "Config: apiKey: \"my-super-secret-api-key-123456\"",
+			expected: "Config: apiKey: [MASKED]",
+		},
+		{
+			name:     "Bearerトークンのマスキング",
+			input:    "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+			expected: "Authorization: Bearer [TOKEN]",
+		},
+		{
+			name:     "複数のトークンを含む場合",
+			input:    "Test with token: ghp_1234567890abcdefghijklmnopqrstuvwxyz and key: sk-proj-abcd1234567890abcdefghijklmnopqrstuvwxyz123456",
+			expected: "Test with token: [GITHUB_TOKEN] and key: [API_KEY]",
+		},
+		{
+			name:     "機密情報を含まない場合",
+			input:    "This is a normal prompt without any sensitive data",
+			expected: "This is a normal prompt without any sensitive data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := executor.maskSensitiveData(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/claude/integration_test.go
+++ b/internal/claude/integration_test.go
@@ -1,0 +1,166 @@
+package claude
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClaudeExecutor_LoggerIntegration(t *testing.T) {
+	t.Run("ロガーを使用したClaude実行フロー", func(t *testing.T) {
+		ml := newMockLogger()
+		executor := NewClaudeExecutorWithLogger(ml)
+		assert.NotNil(t, executor)
+
+		config := &PhaseConfig{
+			Args:   []string{"--test"},
+			Prompt: "/osoba:test {{issue-number}}",
+		}
+		vars := &TemplateVariables{
+			IssueNumber: 123,
+		}
+		workdir := "/test/dir"
+
+		// Claudeコマンドが存在しない環境でのテスト
+		// エラーが発生することを想定
+		err := executor.ExecuteInWorktree(context.Background(), config, vars, workdir)
+		assert.Error(t, err)
+
+		// ログが適切に出力されているか確認
+		// 1. エラーログがあるはず
+		assert.Greater(t, len(ml.errorCalls), 0, "Should have error logs")
+
+		// 2. エラーログの内容を確認
+		foundCommandNotFound := false
+		for _, call := range ml.errorCalls {
+			if call.msg == "Claude command not found" || call.msg == "Failed to execute Claude" {
+				foundCommandNotFound = true
+				break
+			}
+		}
+		assert.True(t, foundCommandNotFound, "Should log error related to Claude execution")
+	})
+
+	t.Run("tmuxでのロガー使用", func(t *testing.T) {
+		ml := newMockLogger()
+		executor := NewClaudeExecutorWithLogger(ml)
+		assert.NotNil(t, executor)
+
+		config := &PhaseConfig{
+			Args:   []string{"--test"},
+			Prompt: "/osoba:test {{issue-number}}",
+		}
+		vars := &TemplateVariables{
+			IssueNumber: 456,
+		}
+		sessionName := "test-session"
+		windowName := "test-window"
+		workdir := "/test/dir"
+
+		// Claudeコマンドが存在しない環境でのテスト
+		err := executor.ExecuteInTmux(context.Background(), config, vars, sessionName, windowName, workdir)
+		assert.Error(t, err)
+
+		// エラーログを確認
+		assert.Greater(t, len(ml.errorCalls), 0, "Should have error logs")
+	})
+
+	t.Run("構造化ログのコンテキスト情報", func(t *testing.T) {
+		ml := newMockLogger()
+		executor := &DefaultClaudeExecutor{
+			logger: ml,
+		}
+
+		// CheckClaudeExistsのテスト
+		_ = executor.CheckClaudeExists()
+
+		// エラーログを確認
+		if len(ml.errorCalls) > 0 {
+			// エラーログが含まれていれば、適切なコンテキストがあることを確認
+			errorCall := ml.errorCalls[0]
+			assert.Equal(t, "Claude command not found", errorCall.msg)
+
+			// key-valueペアが含まれているか確認
+			assert.Greater(t, len(errorCall.keysAndValues), 0, "Should have context in error log")
+		}
+	})
+
+	t.Run("機密情報のマスキング確認", func(t *testing.T) {
+		ml := newMockLogger()
+		executor := &DefaultClaudeExecutor{
+			logger: ml,
+		}
+
+		config := &PhaseConfig{
+			Args:   []string{"--test"},
+			Prompt: "Execute with token ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+		}
+		vars := &TemplateVariables{
+			IssueNumber: 789,
+		}
+		workdir := "/test/dir"
+
+		// 実行（エラーは無視）
+		_ = executor.ExecuteInWorktree(context.Background(), config, vars, workdir)
+
+		// デバッグログを確認
+		for _, call := range ml.debugCalls {
+			for i := 0; i < len(call.keysAndValues); i += 2 {
+				if call.keysAndValues[i] == "prompt" {
+					promptValue := call.keysAndValues[i+1].(string)
+					// トークンがマスクされているか確認
+					assert.Contains(t, promptValue, "[GITHUB_TOKEN]", "Token should be masked")
+					assert.NotContains(t, promptValue, "ghp_1234567890abcdefghijklmnopqrstuvwxyz", "Raw token should not appear")
+				}
+			}
+		}
+	})
+}
+
+func TestClaudeExecutor_LoggerLifecycle(t *testing.T) {
+	t.Run("複数フェーズでのログ出力", func(t *testing.T) {
+		ml := newMockLogger()
+		executor := NewClaudeExecutorWithLogger(ml)
+
+		// 異なるフェーズの設定
+		phases := []struct {
+			name   string
+			config *PhaseConfig
+			vars   *TemplateVariables
+		}{
+			{
+				name: "plan",
+				config: &PhaseConfig{
+					Args:   []string{"--dangerously-skip-permissions"},
+					Prompt: "/osoba:plan {{issue-number}}",
+				},
+				vars: &TemplateVariables{IssueNumber: 100},
+			},
+			{
+				name: "implement",
+				config: &PhaseConfig{
+					Args:   []string{"--dangerously-skip-permissions"},
+					Prompt: "/osoba:implement {{issue-number}}",
+				},
+				vars: &TemplateVariables{IssueNumber: 100},
+			},
+			{
+				name: "review",
+				config: &PhaseConfig{
+					Args:   []string{"--read-only"},
+					Prompt: "/osoba:review {{issue-number}}",
+				},
+				vars: &TemplateVariables{IssueNumber: 100},
+			},
+		}
+
+		// 各フェーズを実行
+		for _, phase := range phases {
+			_ = executor.ExecuteInWorktree(context.Background(), phase.config, phase.vars, "/test/dir")
+		}
+
+		// エラーログが3つ（各フェーズで1つずつ）あることを確認
+		assert.GreaterOrEqual(t, len(ml.errorCalls), 3, "Should have error logs for each phase")
+	})
+}

--- a/internal/claude/logger_test.go
+++ b/internal/claude/logger_test.go
@@ -1,0 +1,85 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/douhashi/osoba/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockLogger はテスト用のモックロガー
+type mockLogger struct {
+	debugCalls []logCall
+	infoCalls  []logCall
+	warnCalls  []logCall
+	errorCalls []logCall
+}
+
+type logCall struct {
+	msg           string
+	keysAndValues []interface{}
+}
+
+func (m *mockLogger) Debug(msg string, keysAndValues ...interface{}) {
+	m.debugCalls = append(m.debugCalls, logCall{msg: msg, keysAndValues: keysAndValues})
+}
+
+func (m *mockLogger) Info(msg string, keysAndValues ...interface{}) {
+	m.infoCalls = append(m.infoCalls, logCall{msg: msg, keysAndValues: keysAndValues})
+}
+
+func (m *mockLogger) Warn(msg string, keysAndValues ...interface{}) {
+	m.warnCalls = append(m.warnCalls, logCall{msg: msg, keysAndValues: keysAndValues})
+}
+
+func (m *mockLogger) Error(msg string, keysAndValues ...interface{}) {
+	m.errorCalls = append(m.errorCalls, logCall{msg: msg, keysAndValues: keysAndValues})
+}
+
+func (m *mockLogger) WithFields(keysAndValues ...interface{}) logger.Logger {
+	return m
+}
+
+// NewMockLogger はテスト用のモックロガーを作成
+func newMockLogger() *mockLogger {
+	return &mockLogger{
+		debugCalls: []logCall{},
+		infoCalls:  []logCall{},
+		warnCalls:  []logCall{},
+		errorCalls: []logCall{},
+	}
+}
+
+func TestMockLogger(t *testing.T) {
+	t.Run("ログメソッドの動作確認", func(t *testing.T) {
+		ml := newMockLogger()
+
+		// 各ログレベルをテスト
+		ml.Debug("debug message", "key", "value")
+		ml.Info("info message", "key", "value")
+		ml.Warn("warn message", "key", "value")
+		ml.Error("error message", "key", "value")
+
+		// 呼び出しを検証
+		assert.Len(t, ml.debugCalls, 1)
+		assert.Equal(t, "debug message", ml.debugCalls[0].msg)
+		assert.Equal(t, []interface{}{"key", "value"}, ml.debugCalls[0].keysAndValues)
+
+		assert.Len(t, ml.infoCalls, 1)
+		assert.Equal(t, "info message", ml.infoCalls[0].msg)
+
+		assert.Len(t, ml.warnCalls, 1)
+		assert.Equal(t, "warn message", ml.warnCalls[0].msg)
+
+		assert.Len(t, ml.errorCalls, 1)
+		assert.Equal(t, "error message", ml.errorCalls[0].msg)
+	})
+
+	t.Run("WithFieldsの動作確認", func(t *testing.T) {
+		ml := newMockLogger()
+
+		// WithFieldsは同じインスタンスを返す
+		logger2 := ml.WithFields("component", "test")
+		assert.Equal(t, ml, logger2)
+	})
+}

--- a/internal/watcher/action_factory_logger_test.go
+++ b/internal/watcher/action_factory_logger_test.go
@@ -73,7 +73,8 @@ func TestActionFactoryWithLogger(t *testing.T) {
 		sessionName := "test-session"
 		ghClient := &github.Client{}
 		worktreeManager := &MockWorktreeManager{}
-		claudeExecutor := claude.NewClaudeExecutor()
+		ml := NewMockLogger()
+		claudeExecutor := claude.NewClaudeExecutorWithLogger(ml)
 		claudeConfig := &claude.ClaudeConfig{}
 
 		// Act
@@ -100,11 +101,12 @@ func TestActionFactoryWithLogger(t *testing.T) {
 	t.Run("PlanActionにloggerが注入されること", func(t *testing.T) {
 		// Arrange
 		testLogger, buf := createTestLogger()
+		ml2 := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml2),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			logger:          testLogger,
@@ -124,11 +126,12 @@ func TestActionFactoryWithLogger(t *testing.T) {
 	t.Run("ImplementationActionにloggerが注入されること", func(t *testing.T) {
 		// Arrange
 		testLogger, buf := createTestLogger()
+		ml2 := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml2),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			config:          config.NewConfig(),
@@ -148,11 +151,12 @@ func TestActionFactoryWithLogger(t *testing.T) {
 	t.Run("ReviewActionにloggerが注入されること", func(t *testing.T) {
 		// Arrange
 		testLogger, buf := createTestLogger()
+		ml2 := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml2),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			config:          config.NewConfig(),
@@ -171,11 +175,12 @@ func TestActionFactoryWithLogger(t *testing.T) {
 
 	t.Run("logger未設定時のデフォルト動作", func(t *testing.T) {
 		// Arrange
+		ml2 := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml2),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			// logger: nil (未設定)

--- a/internal/watcher/action_factory_test.go
+++ b/internal/watcher/action_factory_test.go
@@ -48,7 +48,8 @@ func TestActionFactory(t *testing.T) {
 		sessionName := "test-session"
 		ghClient := &github.Client{}
 		worktreeManager := &MockWorktreeManager{}
-		claudeExecutor := claude.NewClaudeExecutor()
+		ml := NewMockLogger()
+		claudeExecutor := claude.NewClaudeExecutorWithLogger(ml)
 		claudeConfig := &claude.ClaudeConfig{}
 
 		// Act
@@ -75,11 +76,12 @@ func TestActionFactory(t *testing.T) {
 
 	t.Run("CreatePlanActionの作成", func(t *testing.T) {
 		// Arrange
+		ml := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 		}
@@ -94,11 +96,12 @@ func TestActionFactory(t *testing.T) {
 	t.Run("CreatePlanActionの作成 - ghクライアント", func(t *testing.T) {
 		// Arrange
 		mockGhClient := &mockGitHubClient{}
+		ml := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        mockGhClient,
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			config:          config.NewConfig(),
@@ -118,11 +121,12 @@ func TestActionFactory(t *testing.T) {
 
 	t.Run("CreateImplementationActionの作成", func(t *testing.T) {
 		// Arrange
+		ml := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 		}
@@ -137,11 +141,12 @@ func TestActionFactory(t *testing.T) {
 	t.Run("CreateImplementationActionの作成 - ghクライアント", func(t *testing.T) {
 		// Arrange
 		mockGhClient := &mockGitHubClient{}
+		ml := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        mockGhClient,
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			config:          config.NewConfig(),
@@ -158,11 +163,12 @@ func TestActionFactory(t *testing.T) {
 
 	t.Run("CreateReviewActionの作成", func(t *testing.T) {
 		// Arrange
+		ml := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        &github.Client{},
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 		}
@@ -177,11 +183,12 @@ func TestActionFactory(t *testing.T) {
 	t.Run("CreateReviewActionの作成 - ghクライアント", func(t *testing.T) {
 		// Arrange
 		mockGhClient := &mockGitHubClient{}
+		ml := NewMockLogger()
 		factory := &DefaultActionFactory{
 			sessionName:     "test-session",
 			ghClient:        mockGhClient,
 			worktreeManager: &MockWorktreeManager{},
-			claudeExecutor:  claude.NewClaudeExecutor(),
+			claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 			claudeConfig:    &claude.ClaudeConfig{},
 			stateManager:    NewIssueStateManager(),
 			config:          config.NewConfig(),
@@ -202,11 +209,12 @@ func TestActionFactory(t *testing.T) {
 // TestDefaultLabelManager_OwnerRepoNotSet はowner/repoが設定されていない場合の動作を確認
 func TestDefaultLabelManager_OwnerRepoNotSet(t *testing.T) {
 	// Arrange
+	ml := NewMockLogger()
 	factory := &DefaultActionFactory{
 		sessionName:     "test-session",
 		ghClient:        &github.Client{},
 		worktreeManager: &MockWorktreeManager{},
-		claudeExecutor:  claude.NewClaudeExecutor(),
+		claudeExecutor:  claude.NewClaudeExecutorWithLogger(ml),
 		claudeConfig:    &claude.ClaudeConfig{},
 		stateManager:    NewIssueStateManager(),
 		config:          config.NewConfig(),


### PR DESCRIPTION
## 概要
internal/claudeパッケージのログ出力を統一ログシステムに移行しました。Claude実行時の詳細なログ記録により、AI実行状況の把握とデバッグが容易になります。

## 関連するIssue
fixes #118

## 変更内容
### 1. Logger依存性注入の実装
- `NewClaudeExecutorWithLogger()`関数を追加し、loggerの依存性注入を実装
- 既存の`NewClaudeExecutor()`は互換性のため維持

### 2. ログ出力の移行
- 標準ライブラリの`log.Printf`から統一ログシステムへ移行
- 適切なログレベルの設定：
  - INFO: Claude実行開始、完了
  - DEBUG: コマンド詳細、プロンプト内容
  - ERROR: 実行エラー

### 3. 構造化ログの実装
- Issue番号、worktree、セッション情報などのコンテキストを追加
- ログの検索性と分析性を向上

### 4. 機密情報マスキング
- APIキー、GitHubトークン、Bearerトークンなどを自動検出してマスク
- `maskSensitiveData()`メソッドで実装し、ログ出力前に適用

### 5. テストの追加
- モックロガーの実装 (`logger_test.go`)
- マスキング機能の単体テスト (`executor_masking_test.go`)
- 統合テスト (`integration_test.go`)
- 既存テストの更新

### 6. 関連パッケージの更新
- `cmd/start.go`: loggerをClaudeExecutorに渡すよう修正
- `internal/watcher`: テストファイルを新しいAPIに対応

## テスト結果
- [x] ユニットテスト実行済み
- [x] 統合テスト実行済み
- [x] 全体テスト実行済み (`go test ./... -short`)

## レビューポイント
1. 機密情報マスキングのパターンが適切か
2. ログレベルの設定が適切か
3. 構造化ログに含めるコンテキスト情報が十分か

## 今後の検討事項
- Claude API実行時間などのメトリクス追加
- より詳細な進行状況ログの実装