### PR TITLE
feat: グローバル関数の統一ログシステムへの移行

### DIFF
--- a/internal/watcher/retry.go
+++ b/internal/watcher/retry.go
@@ -11,10 +11,98 @@ import (
 	"time"
 
 	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/logger"
 )
 
+// defaultLogger はグローバル関数用のデフォルトロガー
+var defaultLogger logger.Logger
+
+// init はパッケージ初期化時にデフォルトロガーを設定
+func init() {
+	// エラーハンドリングを簡略化するため、エラーが発生した場合はnilロガーを使用
+	l, err := logger.New(logger.WithLevel("info"))
+	if err != nil {
+		// エラーが発生した場合は標準ログに出力
+		log.Printf("Failed to initialize default logger: %v", err)
+		// nilチェックを避けるため、モックロガーを使用
+		defaultLogger = &mockLogger{}
+	} else {
+		defaultLogger = l
+	}
+}
+
+// SetDefaultLogger はテスト用にデフォルトロガーを設定する
+func SetDefaultLogger(l logger.Logger) {
+	defaultLogger = l
+}
+
+// stdLogCompatLogger は標準ログとの互換性を提供するロガー
+type stdLogCompatLogger struct{}
+
+func (s *stdLogCompatLogger) Debug(msg string, keysAndValues ...interface{}) {
+	// RetryWithBackoffは標準ログを使用していたが、デバッグログは出力していなかった
+}
+
+func (s *stdLogCompatLogger) Info(msg string, keysAndValues ...interface{}) {
+	// 既存の動作と同じように標準ログ形式で出力
+	if msg == "Retrying operation" {
+		// 既存のフォーマットを再現
+		var attempt, maxRetries int
+		var backoff time.Duration
+		var errMsg string
+		for i := 0; i < len(keysAndValues)-1; i += 2 {
+			key, ok := keysAndValues[i].(string)
+			if !ok {
+				continue
+			}
+			switch key {
+			case "attempt":
+				attempt, _ = keysAndValues[i+1].(int)
+			case "maxRetries":
+				maxRetries, _ = keysAndValues[i+1].(int)
+			case "backoff":
+				backoff, _ = keysAndValues[i+1].(time.Duration)
+			case "error":
+				errMsg, _ = keysAndValues[i+1].(string)
+			}
+		}
+		log.Printf("Retrying after %v (attempt %d/%d): %s", backoff, attempt, maxRetries, errMsg)
+	}
+}
+
+func (s *stdLogCompatLogger) Warn(msg string, keysAndValues ...interface{}) {
+	if msg == "Rate limit hit, waiting until reset" {
+		// 既存のフォーマットを再現
+		var waitDuration time.Duration
+		for i := 0; i < len(keysAndValues)-1; i += 2 {
+			key, ok := keysAndValues[i].(string)
+			if ok && key == "waitDuration" {
+				waitDuration, _ = keysAndValues[i+1].(time.Duration)
+				break
+			}
+		}
+		log.Printf("Rate limit hit, waiting until reset: %v", waitDuration)
+	}
+}
+
+func (s *stdLogCompatLogger) Error(msg string, keysAndValues ...interface{}) {
+	// RetryWithBackoffは最終的なエラーをログ出力していなかったため、何もしない
+}
+
+func (s *stdLogCompatLogger) WithFields(keysAndValues ...interface{}) logger.Logger {
+	return s
+}
+
 // RetryWithBackoff は指数バックオフでリトライを実行する
+// Deprecated: Use RetryWithBackoffLogger instead. This function will be removed in a future version.
 func RetryWithBackoff(ctx context.Context, maxRetries int, baseDelay time.Duration, operation func() error) error {
+	// 互換性のため、標準ログ出力を使用する特別なロガーを作成
+	compatLogger := &stdLogCompatLogger{}
+	return RetryWithBackoffLogger(ctx, compatLogger, maxRetries, baseDelay, operation)
+}
+
+// RetryWithBackoffLogger は指数バックオフでリトライを実行する（logger付き）
+func RetryWithBackoffLogger(ctx context.Context, logger logger.Logger, maxRetries int, baseDelay time.Duration, operation func() error) error {
 	if maxRetries <= 0 {
 		maxRetries = 1
 	}
@@ -36,7 +124,7 @@ func RetryWithBackoff(ctx context.Context, maxRetries int, baseDelay time.Durati
 		lastErr = err
 
 		// リトライ可能なエラーかチェック
-		if !IsRetryableError(err) {
+		if !IsRetryableErrorLogger(logger, err) {
 			return err
 		}
 
@@ -46,7 +134,7 @@ func RetryWithBackoff(ctx context.Context, maxRetries int, baseDelay time.Durati
 		}
 
 		// バックオフ時間を計算
-		backoff := CalculateBackoff(attempt+1, baseDelay)
+		backoff := CalculateBackoffLogger(logger, attempt+1, baseDelay)
 		errMsg := "unknown error"
 		if err != nil {
 			// エラーメッセージを安全に取得
@@ -59,12 +147,18 @@ func RetryWithBackoff(ctx context.Context, maxRetries int, baseDelay time.Durati
 				errMsg = err.Error()
 			}()
 		}
-		log.Printf("Retrying after %v (attempt %d/%d): %s", backoff, attempt+1, maxRetries, errMsg)
+		// 互換性のために、Retrying operationはInfoレベルで出力
+		logger.Info("Retrying operation",
+			"attempt", attempt+1,
+			"maxRetries", maxRetries,
+			"backoff", backoff,
+			"error", errMsg)
 
 		// レート制限エラーの場合は特別な処理
-		if sleepDuration, ok := HandleRateLimitError(err); ok && sleepDuration > 0 {
+		if sleepDuration, ok := HandleRateLimitErrorLogger(logger, err); ok && sleepDuration > 0 {
 			backoff = sleepDuration
-			log.Printf("Rate limit hit, waiting until reset: %v", backoff)
+			logger.Warn("Rate limit hit, waiting until reset",
+				"waitDuration", backoff)
 		}
 
 		// バックオフ時間待機
@@ -76,11 +170,20 @@ func RetryWithBackoff(ctx context.Context, maxRetries int, baseDelay time.Durati
 		}
 	}
 
+	logger.Error("Max retries exceeded",
+		"maxRetries", maxRetries,
+		"error", lastErr)
 	return fmt.Errorf("max retries (%d) exceeded: %w", maxRetries, lastErr)
 }
 
 // IsRetryableError はエラーがリトライ可能かどうかを判定する
+// Deprecated: Use IsRetryableErrorLogger instead. This function will be removed in a future version.
 func IsRetryableError(err error) bool {
+	return IsRetryableErrorLogger(defaultLogger, err)
+}
+
+// IsRetryableErrorLogger はエラーがリトライ可能かどうかを判定する（logger付き）
+func IsRetryableErrorLogger(logger logger.Logger, err error) bool {
 	if err == nil {
 		return false
 	}
@@ -88,6 +191,9 @@ func IsRetryableError(err error) bool {
 	// GitHub APIのレート制限エラー
 	var rateLimitErr *github.RateLimitError
 	if errors.As(err, &rateLimitErr) {
+		logger.Debug("Error is retryable",
+			"errorType", "RateLimitError",
+			"error", err)
 		return true
 	}
 
@@ -97,9 +203,15 @@ func IsRetryableError(err error) bool {
 		// エラーメッセージでサーバーエラーやレート制限を判定
 		msg := strings.ToLower(errResp.Message)
 		if strings.Contains(msg, "server error") || strings.Contains(msg, "internal server error") || strings.Contains(msg, "service unavailable") || strings.Contains(msg, "bad gateway") {
+			logger.Debug("Error is retryable",
+				"errorType", "ServerError",
+				"error", err)
 			return true
 		}
 		if strings.Contains(msg, "rate limit") || strings.Contains(msg, "too many requests") {
+			logger.Debug("Error is retryable",
+				"errorType", "RateLimit",
+				"error", err)
 			return true
 		}
 	}
@@ -107,19 +219,33 @@ func IsRetryableError(err error) bool {
 	// ネットワークタイムアウトエラー
 	errStr := err.Error()
 	if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "Client.Timeout exceeded") {
+		logger.Debug("Error is retryable",
+			"errorType", "Timeout",
+			"error", err)
 		return true
 	}
 
 	// 一時的なネットワークエラー
 	if strings.Contains(errStr, "connection refused") || strings.Contains(errStr, "no such host") {
+		logger.Debug("Error is retryable",
+			"errorType", "NetworkError",
+			"error", err)
 		return true
 	}
 
+	logger.Debug("Error is not retryable",
+		"error", err)
 	return false
 }
 
 // CalculateBackoff は指数バックオフの遅延時間を計算する
+// Deprecated: Use CalculateBackoffLogger instead. This function will be removed in a future version.
 func CalculateBackoff(attempt int, baseDelay time.Duration) time.Duration {
+	return CalculateBackoffLogger(defaultLogger, attempt, baseDelay)
+}
+
+// CalculateBackoffLogger は指数バックオフの遅延時間を計算する（logger付き）
+func CalculateBackoffLogger(logger logger.Logger, attempt int, baseDelay time.Duration) time.Duration {
 	if attempt <= 0 {
 		attempt = 1
 	}
@@ -135,13 +261,27 @@ func CalculateBackoff(attempt int, baseDelay time.Duration) time.Duration {
 	maxDelay := float64(60 * time.Second)
 	if delay > maxDelay {
 		delay = maxDelay
+		logger.Debug("Backoff delay capped at max",
+			"maxDelay", time.Duration(maxDelay),
+			"attempt", attempt)
+	} else {
+		logger.Debug("Calculated backoff delay",
+			"delay", time.Duration(delay),
+			"attempt", attempt,
+			"baseDelay", baseDelay)
 	}
 
 	return time.Duration(delay)
 }
 
 // HandleRateLimitError はGitHub APIのレート制限エラーを処理する
+// Deprecated: Use HandleRateLimitErrorLogger instead. This function will be removed in a future version.
 func HandleRateLimitError(err error) (time.Duration, bool) {
+	return HandleRateLimitErrorLogger(defaultLogger, err)
+}
+
+// HandleRateLimitErrorLogger はGitHub APIのレート制限エラーを処理する（logger付き）
+func HandleRateLimitErrorLogger(logger logger.Logger, err error) (time.Duration, bool) {
 	var rateLimitErr *github.RateLimitError
 	if !errors.As(err, &rateLimitErr) {
 		return 0, false
@@ -154,9 +294,14 @@ func HandleRateLimitError(err error) (time.Duration, bool) {
 		if sleepDuration > 0 {
 			// 少し余裕を持たせる（1秒追加）
 			sleepDuration += time.Second
+			logger.Debug("Rate limit reset time calculated",
+				"resetTime", resetTime,
+				"sleepDuration", sleepDuration)
 			return sleepDuration, true
 		}
 	}
 
+	logger.Debug("Rate limit error has no valid reset time",
+		"error", err)
 	return 0, false
 }

--- a/internal/watcher/retry_with_logger_test.go
+++ b/internal/watcher/retry_with_logger_test.go
@@ -1,0 +1,282 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/logger"
+)
+
+// TestRetryWithBackoffLogger tests the new RetryWithBackoffLogger function
+func TestRetryWithBackoffLogger(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxRetries   int
+		operation    func() error
+		wantErr      bool
+		wantAttempts int
+		checkLogs    func(t *testing.T, logs []MockLogEntry)
+	}{
+		{
+			name:       "正常系: 初回成功",
+			maxRetries: 3,
+			operation: func() error {
+				return nil
+			},
+			wantErr:      false,
+			wantAttempts: 1,
+			checkLogs: func(t *testing.T, logs []MockLogEntry) {
+				// 成功時はログなし
+				if len(logs) != 0 {
+					t.Errorf("Expected no logs, got %d logs", len(logs))
+				}
+			},
+		},
+		{
+			name:       "正常系: 2回目で成功",
+			maxRetries: 3,
+			operation: func() func() error {
+				attempt := 0
+				return func() error {
+					attempt++
+					if attempt < 2 {
+						return &github.RateLimitError{
+							Message: "API rate limit exceeded",
+							Rate: github.RateLimit{
+								Reset: time.Now().Add(time.Second),
+							},
+						}
+					}
+					return nil
+				}
+			}(),
+			wantErr:      false,
+			wantAttempts: 2,
+			checkLogs: func(t *testing.T, logs []MockLogEntry) {
+				// リトライログとレート制限ログがあるはず
+				if len(logs) < 2 {
+					t.Errorf("Expected at least 2 logs, got %d", len(logs))
+					return
+				}
+
+				// ログレベルを確認
+				hasRetryLog := false
+				hasRateLimitLog := false
+				for _, log := range logs {
+					// RetryWithBackoffLoggerではINFOレベルで出力される
+					if log.Level == "INFO" && log.Message == "Retrying operation" {
+						hasRetryLog = true
+					}
+					if log.Level == "WARN" && log.Message == "Rate limit hit, waiting until reset" {
+						hasRateLimitLog = true
+					}
+				}
+
+				if !hasRetryLog {
+					t.Error("Expected retry log but not found")
+				}
+				if !hasRateLimitLog {
+					t.Error("Expected rate limit warning log but not found")
+				}
+			},
+		},
+		{
+			name:       "異常系: 最大リトライ回数超過",
+			maxRetries: 2,
+			operation: func() error {
+				return &github.ErrorResponse{
+					Message: "Service Unavailable",
+				}
+			},
+			wantErr:      true,
+			wantAttempts: 2,
+			checkLogs: func(t *testing.T, logs []MockLogEntry) {
+				// 各リトライのログとエラーログがあるはず
+				infoLogs := 0
+				debugLogs := 0
+				errorLogs := 0
+				for _, log := range logs {
+					switch log.Level {
+					case "INFO":
+						infoLogs++
+					case "DEBUG":
+						debugLogs++
+					case "ERROR":
+						errorLogs++
+					}
+				}
+
+				// Retrying operationのINFOログと、IsRetryableErrorのDEBUGログ
+				if infoLogs < 1 {
+					t.Errorf("Expected at least 1 INFO log, got %d", infoLogs)
+				}
+				if debugLogs < 1 {
+					t.Errorf("Expected at least 1 DEBUG log, got %d", debugLogs)
+				}
+				if errorLogs != 1 {
+					t.Errorf("Expected 1 ERROR log, got %d", errorLogs)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 各テストケースで新しいモックロガーを使用
+			testLogger := NewMockLogger()
+
+			attempts := 0
+			countingOperation := func() error {
+				attempts++
+				return tt.operation()
+			}
+
+			err := RetryWithBackoffLogger(context.Background(), testLogger, tt.maxRetries, 10*time.Millisecond, countingOperation)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RetryWithBackoffLogger() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if attempts != tt.wantAttempts {
+				t.Errorf("RetryWithBackoffLogger() attempts = %v, want %v", attempts, tt.wantAttempts)
+			}
+
+			// ログの検証
+			if mockLog, ok := testLogger.(*mockLogger); ok {
+				tt.checkLogs(t, mockLog.GetLogs())
+			}
+		})
+	}
+}
+
+// TestIsRetryableErrorLogger tests the new IsRetryableErrorLogger function
+func TestIsRetryableErrorLogger(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		want      bool
+		checkLogs func(t *testing.T, logs []MockLogEntry)
+	}{
+		{
+			name: "GitHub APIレート制限エラー",
+			err: &github.RateLimitError{
+				Message: "API rate limit exceeded",
+			},
+			want: true,
+			checkLogs: func(t *testing.T, logs []MockLogEntry) {
+				if len(logs) != 1 {
+					t.Errorf("Expected 1 log, got %d", len(logs))
+					return
+				}
+				if logs[0].Level != "DEBUG" {
+					t.Errorf("Expected DEBUG log, got %s", logs[0].Level)
+				}
+				if logs[0].Message != "Error is retryable" {
+					t.Errorf("Expected retryable message, got %s", logs[0].Message)
+				}
+			},
+		},
+		{
+			name: "リトライ不可能なエラー",
+			err:  errors.New("not found"),
+			want: false,
+			checkLogs: func(t *testing.T, logs []MockLogEntry) {
+				if len(logs) != 1 {
+					t.Errorf("Expected 1 log, got %d", len(logs))
+					return
+				}
+				if logs[0].Level != "DEBUG" {
+					t.Errorf("Expected DEBUG log, got %s", logs[0].Level)
+				}
+				if logs[0].Message != "Error is not retryable" {
+					t.Errorf("Expected not retryable message, got %s", logs[0].Message)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLogger := NewMockLogger()
+
+			got := IsRetryableErrorLogger(testLogger, tt.err)
+			if got != tt.want {
+				t.Errorf("IsRetryableErrorLogger() = %v, want %v", got, tt.want)
+			}
+
+			// ログの検証
+			if mockLog, ok := testLogger.(*mockLogger); ok {
+				tt.checkLogs(t, mockLog.GetLogs())
+			}
+		})
+	}
+}
+
+// TestMigrationCompatibility tests that old function calls still work
+func TestMigrationCompatibility(t *testing.T) {
+	t.Run("RetryWithBackoff互換性", func(t *testing.T) {
+		attempts := 0
+		operation := func() error {
+			attempts++
+			if attempts < 2 {
+				return &github.RateLimitError{
+					Message: "API rate limit exceeded",
+					Rate: github.RateLimit{
+						Reset: time.Now().Add(100 * time.Millisecond),
+					},
+				}
+			}
+			return nil
+		}
+
+		// 既存の関数が引き続き動作することを確認
+		err := RetryWithBackoff(context.Background(), 3, 10*time.Millisecond, operation)
+		if err != nil {
+			t.Errorf("RetryWithBackoff() returned unexpected error: %v", err)
+		}
+
+		if attempts != 2 {
+			t.Errorf("Expected 2 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("IsRetryableError互換性", func(t *testing.T) {
+		err := &github.RateLimitError{Message: "rate limit"}
+
+		// 既存の関数が引き続き動作することを確認
+		if !IsRetryableError(err) {
+			t.Error("IsRetryableError() should return true for rate limit error")
+		}
+	})
+}
+
+// TestLoggerIntegration tests integration with real logger
+func TestLoggerIntegration(t *testing.T) {
+	// 実際のロガー実装を使用したテスト
+	realLogger, err := logger.New(logger.WithLevel("debug"))
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+
+	attempts := 0
+	operation := func() error {
+		attempts++
+		if attempts < 3 {
+			return &github.ErrorResponse{
+				Message: "Internal Server Error",
+			}
+		}
+		return nil
+	}
+
+	err = RetryWithBackoffLogger(context.Background(), realLogger, 5, 10*time.Millisecond, operation)
+	if err != nil {
+		t.Errorf("RetryWithBackoffLogger() returned unexpected error: %v", err)
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+}

--- a/internal/watcher/test_helpers.go
+++ b/internal/watcher/test_helpers.go
@@ -1,19 +1,80 @@
 package watcher
 
-import "github.com/douhashi/osoba/internal/logger"
+import (
+	"sync"
+
+	"github.com/douhashi/osoba/internal/logger"
+)
+
+// MockLogEntry represents a single log entry for testing
+type MockLogEntry struct {
+	Level   string
+	Message string
+	Fields  []interface{}
+}
 
 // mockLogger はテスト用のモックロガー
-type mockLogger struct{}
+type mockLogger struct {
+	mu   sync.Mutex
+	logs []MockLogEntry
+}
 
-func (m *mockLogger) Debug(msg string, keysAndValues ...interface{}) {}
-func (m *mockLogger) Info(msg string, keysAndValues ...interface{})  {}
-func (m *mockLogger) Warn(msg string, keysAndValues ...interface{})  {}
-func (m *mockLogger) Error(msg string, keysAndValues ...interface{}) {}
+func (m *mockLogger) Debug(msg string, keysAndValues ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, MockLogEntry{
+		Level:   "DEBUG",
+		Message: msg,
+		Fields:  keysAndValues,
+	})
+}
+
+func (m *mockLogger) Info(msg string, keysAndValues ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, MockLogEntry{
+		Level:   "INFO",
+		Message: msg,
+		Fields:  keysAndValues,
+	})
+}
+
+func (m *mockLogger) Warn(msg string, keysAndValues ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, MockLogEntry{
+		Level:   "WARN",
+		Message: msg,
+		Fields:  keysAndValues,
+	})
+}
+
+func (m *mockLogger) Error(msg string, keysAndValues ...interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, MockLogEntry{
+		Level:   "ERROR",
+		Message: msg,
+		Fields:  keysAndValues,
+	})
+}
+
 func (m *mockLogger) WithFields(keysAndValues ...interface{}) logger.Logger {
 	return m
 }
 
+// GetLogs returns all logged entries
+func (m *mockLogger) GetLogs() []MockLogEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]MockLogEntry, len(m.logs))
+	copy(result, m.logs)
+	return result
+}
+
 // NewMockLogger はテスト用のモックロガーを作成
 func NewMockLogger() logger.Logger {
-	return &mockLogger{}
+	return &mockLogger{
+		logs: make([]MockLogEntry, 0),
+	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -224,7 +224,7 @@ func (w *IssueWatcher) checkIssues(ctx context.Context, callback IssueCallback) 
 		// ポーリング間隔が1秒未満の場合（テスト環境）は短いリトライ間隔を使用
 		retryDelay = 100 * time.Millisecond
 	}
-	err := RetryWithBackoff(ctx, 3, retryDelay, func() error {
+	err := RetryWithBackoffLogger(ctx, w.logger, 3, retryDelay, func() error {
 		var err error
 		issues, err = w.client.ListIssuesByLabels(ctx, w.owner, w.repo, w.labels)
 		return err


### PR DESCRIPTION
## 概要
retry.goなどのグローバル関数のログ出力を統一ログシステムで管理できるようにしました。

## 背景
- Issue #101で統一ログシステムへの移行が部分的に完了
- retry.goなどのグローバル関数は関数シグネチャの制約でloggerを渡せず、一貫性のないログ出力になっていた
- 統一ログシステムへの完全移行の最終段階として、破壊的変更を含む慎重な対応が必要だった

## 変更内容
- 🆕 logger パラメータを持つ新しい関数を追加
  - `RetryWithBackoffLogger`
  - `IsRetryableErrorLogger`
  - `CalculateBackoffLogger`
  - `HandleRateLimitErrorLogger`
- 🔧 既存関数を新しい関数へのラッパーとして実装（後方互換性を維持）
- 📝 互換性のためのstdLogCompatLoggerを実装（既存の標準ログ出力を維持）
- ✅ 各新関数に対するテストを追加
- 🔄 watcher.goをRetryWithBackoffLoggerを使用するよう更新

## テスト結果
- [x] 既存のテストが全て通る
- [x] 新しいテストが全て通る  
- [x] システム全体のテストが通る
- [x] 既存の関数との互換性テストが通る

## マイグレーション戦略
段階的移行アプローチを採用：
1. 新しい関数を追加（現在）
2. 既存関数にDeprecatedコメントを追加
3. 全ての呼び出し元を新しい関数に移行
4. 十分な移行期間後、既存関数を削除

fixes #119

🤖 Generated with [Claude Code](https://claude.ai/code)