### PR TITLE
feat: tmuxウィンドウ/pane管理の改善 - 新規ウィンドウ作成時のpane分割無効化と縦分割対応

### DIFF
--- a/internal/tmux/window_issue.go
+++ b/internal/tmux/window_issue.go
@@ -31,3 +31,71 @@ func ParseWindowNameForIssue(windowName string) (int, error) {
 func IsNewFormatIssueWindow(windowName string) bool {
 	return strings.HasPrefix(windowName, "issue-")
 }
+
+// CreateWindowForIssueWithNewWindowDetection はIssue番号に基づいてウィンドウを作成し、新規作成かどうかを返す
+//
+// 戻り値:
+//   - string: ウィンドウ名（"issue-{番号}"形式）
+//   - bool: 新規作成された場合はtrue、既存の場合はfalse
+//   - error: エラーが発生した場合
+func CreateWindowForIssueWithNewWindowDetection(sessionName string, issueNumber int, executor CommandExecutor) (string, bool, error) {
+	if sessionName == "" {
+		return "", false, fmt.Errorf("session name cannot be empty")
+	}
+	if issueNumber <= 0 {
+		return "", false, fmt.Errorf("issue number must be positive")
+	}
+
+	windowName := GetWindowNameForIssue(issueNumber)
+
+	if logger := GetLogger(); logger != nil {
+		logger.Info("Issue用ウィンドウ作成開始（新規判定付き）",
+			"operation", "create_window_for_issue_with_detection",
+			"session_name", sessionName,
+			"issue_number", issueNumber,
+			"window_name", windowName)
+	}
+
+	// ウィンドウが既に存在するかチェック
+	exists, err := WindowExistsWithExecutor(sessionName, windowName, executor)
+	if err != nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Error("ウィンドウ存在チェック失敗",
+				"session_name", sessionName,
+				"window_name", windowName,
+				"error", err)
+		}
+		return "", false, fmt.Errorf("failed to check window existence for issue %d: %w", issueNumber, err)
+	}
+
+	if exists {
+		if logger := GetLogger(); logger != nil {
+			logger.Info("既存ウィンドウを使用",
+				"session_name", sessionName,
+				"window_name", windowName,
+				"is_new_window", false)
+		}
+		return windowName, false, nil
+	}
+
+	// 新規ウィンドウを作成
+	err = CreateWindowWithExecutor(sessionName, windowName, executor)
+	if err != nil {
+		if logger := GetLogger(); logger != nil {
+			logger.Error("新規ウィンドウ作成失敗",
+				"session_name", sessionName,
+				"window_name", windowName,
+				"error", err)
+		}
+		return "", false, fmt.Errorf("failed to create window for issue %d: %w", issueNumber, err)
+	}
+
+	if logger := GetLogger(); logger != nil {
+		logger.Info("新規ウィンドウ作成完了",
+			"session_name", sessionName,
+			"window_name", windowName,
+			"is_new_window", true)
+	}
+
+	return windowName, true, nil
+}

--- a/internal/tmux/window_issue_test.go
+++ b/internal/tmux/window_issue_test.go
@@ -262,3 +262,198 @@ func TestSwitchToIssueWindow(t *testing.T) {
 		mockExec.AssertExpectations(t)
 	})
 }
+
+func TestCreateWindowForIssueWithNewWindowDetection(t *testing.T) {
+	t.Run("正常系: 新規ウィンドウを作成し、isNewWindowがtrueを返す", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 149
+		windowName := "issue-149"
+
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// WindowExists check - returns false (window doesn't exist)
+		mockExec.On("Execute", "tmux", []string{"list-windows", "-t", sessionName, "-F", "#{window_name}"}).Return("issue-1\nissue-2\n", nil)
+
+		// Create new window
+		mockExec.On("Execute", "tmux", []string{"new-window", "-t", sessionName, "-n", windowName}).Return("", nil)
+
+		// Act
+		actualWindowName, isNewWindow, err := tmux.CreateWindowForIssueWithNewWindowDetection(sessionName, issueNumber, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, "issue-149", actualWindowName)
+		assert.True(t, isNewWindow)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: 既存ウィンドウが存在し、isNewWindowがfalseを返す", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 149
+		expectedWindowName := "issue-149"
+
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// WindowExists check - returns true (window exists)
+		mockExec.On("Execute", "tmux", []string{"list-windows", "-t", sessionName, "-F", "#{window_name}"}).Return("issue-1\nissue-149\nissue-2\n", nil)
+
+		// Act
+		actualWindowName, isNewWindow, err := tmux.CreateWindowForIssueWithNewWindowDetection(sessionName, issueNumber, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expectedWindowName, actualWindowName)
+		assert.False(t, isNewWindow)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: tmuxコマンドがエラーを返す", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		issueNumber := 149
+		expectedErr := errors.New("session not found")
+
+		mockExec := mocks.NewMockCommandExecutor()
+		mockExec.On("Execute", "tmux", []string{"list-windows", "-t", sessionName, "-F", "#{window_name}"}).Return("", expectedErr)
+
+		// Act
+		actualWindowName, isNewWindow, err := tmux.CreateWindowForIssueWithNewWindowDetection(sessionName, issueNumber, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Equal(t, "", actualWindowName)
+		assert.False(t, isNewWindow)
+		mockExec.AssertExpectations(t)
+	})
+}
+
+func TestSelectOrCreatePaneForPhaseWithNewWindowFlag(t *testing.T) {
+	t.Run("正常系: 新規ウィンドウの場合、pane分割をスキップ", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		windowName := "issue-149"
+		paneTitle := "plan-phase"
+		isNewWindow := true
+
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// List panes - return single pane (default pane)
+		mockExec.On("Execute", "tmux", []string{"list-panes", "-t", sessionName + ":" + windowName, "-F", "#{pane_index}:#{pane_title}"}).Return("0:\n", nil)
+
+		// Select the first pane and set title
+		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName + ".0"}).Return("", nil)
+		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName, "-T", paneTitle}).Return("", nil)
+
+		// Act
+		paneTarget, err := tmux.SelectOrCreatePaneForPhaseWithNewWindowFlag(sessionName, windowName, paneTitle, isNewWindow, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, sessionName+":"+windowName+".0", paneTarget)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: 既存ウィンドウの場合、縦分割でpaneを作成", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		windowName := "issue-149"
+		paneTitle := "implement-phase"
+		isNewWindow := false
+
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// List panes - return single pane (no matching pane found)
+		mockExec.On("Execute", "tmux", []string{"list-panes", "-t", sessionName + ":" + windowName, "-F", "#{pane_index}:#{pane_title}"}).Return("0:plan-phase\n", nil)
+
+		// Create new pane with horizontal split (-h)
+		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-h", "-p", "50"}).Return("", nil)
+
+		// Set pane title
+		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName, "-T", paneTitle}).Return("", nil)
+
+		// Act
+		paneTarget, err := tmux.SelectOrCreatePaneForPhaseWithNewWindowFlag(sessionName, windowName, paneTitle, isNewWindow, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, sessionName+":"+windowName, paneTarget)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("正常系: 既存ウィンドウで既存paneが見つかった場合、そのpaneを選択", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		windowName := "issue-149"
+		paneTitle := "plan-phase"
+		isNewWindow := false
+
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// List panes - return pane with matching title
+		mockExec.On("Execute", "tmux", []string{"list-panes", "-t", sessionName + ":" + windowName, "-F", "#{pane_index}:#{pane_title}"}).Return("0:plan-phase\n1:implement-phase\n", nil)
+
+		// Select existing pane
+		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName + ".0"}).Return("", nil)
+
+		// Act
+		paneTarget, err := tmux.SelectOrCreatePaneForPhaseWithNewWindowFlag(sessionName, windowName, paneTitle, isNewWindow, mockExec)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, sessionName+":"+windowName+".0", paneTarget)
+		mockExec.AssertExpectations(t)
+	})
+
+	t.Run("異常系: 空のセッション名", func(t *testing.T) {
+		// Arrange
+		sessionName := ""
+		windowName := "issue-149"
+		paneTitle := "plan-phase"
+		isNewWindow := false
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// Act
+		paneTarget, err := tmux.SelectOrCreatePaneForPhaseWithNewWindowFlag(sessionName, windowName, paneTitle, isNewWindow, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Equal(t, "", paneTarget)
+		assert.Contains(t, err.Error(), "session name cannot be empty")
+	})
+
+	t.Run("異常系: 空のウィンドウ名", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		windowName := ""
+		paneTitle := "plan-phase"
+		isNewWindow := false
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// Act
+		paneTarget, err := tmux.SelectOrCreatePaneForPhaseWithNewWindowFlag(sessionName, windowName, paneTitle, isNewWindow, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Equal(t, "", paneTarget)
+		assert.Contains(t, err.Error(), "window name cannot be empty")
+	})
+
+	t.Run("異常系: 空のpaneタイトル", func(t *testing.T) {
+		// Arrange
+		sessionName := "osoba-test"
+		windowName := "issue-149"
+		paneTitle := ""
+		isNewWindow := false
+		mockExec := mocks.NewMockCommandExecutor()
+
+		// Act
+		paneTarget, err := tmux.SelectOrCreatePaneForPhaseWithNewWindowFlag(sessionName, windowName, paneTitle, isNewWindow, mockExec)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Equal(t, "", paneTarget)
+		assert.Contains(t, err.Error(), "pane title cannot be empty")
+	})
+}


### PR DESCRIPTION
## 概要
Issue #149のtmuxウィンドウ/pane管理の改善を実装しました。新規ウィンドウ作成時のpane分割無効化と縦分割対応を実現しています。

## 関連するIssue
fixes #149

## 変更内容
- **新規ウィンドウ作成時のpane分割無効化**: 新規作成されたウィンドウでは不要なpane分割を実行せず、既存のpaneを使用
- **縦分割対応**: 既存ウィンドウでのAction実行時は縦分割（`-h`）でpaneを作成し、画面使用効率を向上
- **新機能の追加**:
  - `CreateWindowForIssueWithNewWindowDetection`: 新規ウィンドウ作成時の判定機能
  - `SelectOrCreatePaneForPhaseWithNewWindowFlag`: 新規ウィンドウフラグ対応のpane管理
- **ログ機能の充実**: 詳細なログ出力とエラーハンドリングを実装
- **TDDによる品質保証**: 包括的なテストケースを追加

## 技術的な詳細
### 主な変更点
1. **`internal/tmux/window_issue.go`**: 新規ウィンドウ作成判定機能を追加
2. **`internal/tmux/window.go`**: 新規ウィンドウフラグ対応のpane管理機能を追加
3. **`internal/tmux/window_issue_test.go`**: 新機能の包括的テストケースを追加

### 実装アプローチ
- **TDD**: テストファーストでの開発により品質を保証
- **リファクタリング**: 既存機能への影響を最小化
- **段階的実装**: 新機能を段階的に追加し、既存テストとの整合性を維持

## テスト結果
- 新機能のテストケース: **全て通過**
- 既存機能のテストケース: **全て通過**
- tmuxパッケージの全テスト: **全て通過**

## 受け入れ条件の確認
- [x] 新しいウィンドウ（`issue-{issue番号}`）を作成する際、pane分割を実行しない
- [x] 既存のウィンドウがある場合のみ、Action実行時にpane分割を実行する
- [x] pane分割は縦分割（`split-window -h`）を使用する
- [x] 既存のウィンドウ作成機能に影響を与えない
- [x] tmuxセッション管理の他の機能に影響を与えない

## レビューポイント
1. 新機能の動作確認（テストケース参照）
2. 既存機能への影響がないことの確認
3. エラーハンドリングとログ出力の適切性
4. コードの可読性と保守性
EOF < /dev/null