### PR TITLE
feat: tmux pane分割を縦分割に変更 (#152)

### DIFF
--- a/internal/tmux/pane_test.go
+++ b/internal/tmux/pane_test.go
@@ -31,18 +31,18 @@ func TestDefaultManager_CreatePane(t *testing.T) {
 		errMessage  string
 	}{
 		{
-			name:        "create vertical pane successfully",
+			name:        "create horizontal pane successfully",
 			sessionName: "osoba-test",
 			windowName:  "issue-123",
 			opts: PaneOptions{
-				Split:      "-v",
+				Split:      "-h",
 				Percentage: 50,
 				Title:      "Implementation",
 			},
 			setupMock: func(m *MockCommandExecutor) {
 				// split-window command
 				m.On("Execute", "tmux", []string{
-					"split-window", "-v", "-p", "50", "-t", "osoba-test:issue-123",
+					"split-window", "-h", "-p", "50", "-t", "osoba-test:issue-123",
 				}).Return("", nil).Once()
 
 				// list-panes to get new pane info
@@ -105,12 +105,12 @@ func TestDefaultManager_CreatePane(t *testing.T) {
 			sessionName: "osoba-test",
 			windowName:  "non-existent",
 			opts: PaneOptions{
-				Split: "-v",
+				Split: "-h",
 				Title: "Test",
 			},
 			setupMock: func(m *MockCommandExecutor) {
 				m.On("Execute", "tmux", []string{
-					"split-window", "-v", "-p", "50", "-t", "osoba-test:non-existent",
+					"split-window", "-h", "-p", "50", "-t", "osoba-test:non-existent",
 				}).Return("", fmt.Errorf("can't find window: non-existent")).Once()
 			},
 			want:       nil,

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -737,7 +737,7 @@ func CreatePaneInWindowWithExecutor(sessionName, windowName, paneTitle string, e
 	}
 
 	// paneを分割作成
-	_, err := executor.Execute("tmux", "split-window", "-t", target, "-v", "-p", "50")
+	_, err := executor.Execute("tmux", "split-window", "-t", target, "-h", "-p", "50")
 	if err != nil {
 		if logger := GetLogger(); logger != nil {
 			logger.Error("tmuxペイン作成失敗",
@@ -944,7 +944,7 @@ func SelectOrCreatePaneForPhaseWithExecutor(sessionName, windowName, paneTitle s
 	}
 
 	// 新しいpaneを作成
-	_, err = executor.Execute("tmux", "split-window", "-t", target, "-v", "-p", splitPercentage)
+	_, err = executor.Execute("tmux", "split-window", "-t", target, "-h", "-p", splitPercentage)
 	if err != nil {
 		return fmt.Errorf("failed to create new pane: %w", err)
 	}

--- a/internal/tmux/window_test.go
+++ b/internal/tmux/window_test.go
@@ -994,7 +994,7 @@ func TestPaneManagement(t *testing.T) {
 
 		mockExec := mocks.NewMockCommandExecutor()
 		// split-window コマンドでpaneを作成
-		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-v", "-p", "50"}).Return("", nil)
+		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-h", "-p", "50"}).Return("", nil)
 		// paneにタイトルを設定
 		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName, "-T", paneTitle}).Return("", nil)
 
@@ -1056,7 +1056,7 @@ func TestPaneManagement(t *testing.T) {
 		// pane一覧取得（target paneが存在しない）
 		mockExec.On("Execute", "tmux", []string{"list-panes", "-t", sessionName + ":" + windowName, "-F", "#{pane_index}:#{pane_title}"}).Return("0:plan-phase\n1:implement-phase", nil)
 		// 新しいpaneを作成
-		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-v", "-p", "33"}).Return("", nil)
+		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-h", "-p", "33"}).Return("", nil)
 		// paneにタイトルを設定
 		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName, "-T", paneTitle}).Return("", nil)
 
@@ -1092,7 +1092,7 @@ func TestPhaseIntegration(t *testing.T) {
 		mockExec.On("Execute", "tmux", []string{"list-windows", "-t", sessionName, "-F", "#{window_name}"}).Return(windowName, nil).Once()
 		// 2. Implementation pane作成
 		mockExec.On("Execute", "tmux", []string{"list-panes", "-t", sessionName + ":" + windowName, "-F", "#{pane_index}:#{pane_title}"}).Return("0:plan-phase", nil).Once()
-		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-v", "-p", "50"}).Return("", nil).Times(2)
+		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-h", "-p", "50"}).Return("", nil).Times(2)
 		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName, "-T", "implement-phase"}).Return("", nil).Once()
 
 		// Review フェーズ
@@ -1100,7 +1100,7 @@ func TestPhaseIntegration(t *testing.T) {
 		mockExec.On("Execute", "tmux", []string{"list-windows", "-t", sessionName, "-F", "#{window_name}"}).Return(windowName, nil).Once()
 		// 2. Review pane作成
 		mockExec.On("Execute", "tmux", []string{"list-panes", "-t", sessionName + ":" + windowName, "-F", "#{pane_index}:#{pane_title}"}).Return("0:plan-phase\n1:implement-phase", nil).Once()
-		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-v", "-p", "33"}).Return("", nil).Once()
+		mockExec.On("Execute", "tmux", []string{"split-window", "-t", sessionName + ":" + windowName, "-h", "-p", "33"}).Return("", nil).Once()
 		mockExec.On("Execute", "tmux", []string{"select-pane", "-t", sessionName + ":" + windowName, "-T", "review-phase"}).Return("", nil).Once()
 
 		// Act & Assert

--- a/internal/watcher/actions/base_executor.go
+++ b/internal/watcher/actions/base_executor.go
@@ -125,7 +125,7 @@ func (e *BaseExecutor) ensurePane(windowName string, phase string) (*tmuxpkg.Pan
 
 	// フェーズに応じたpane作成オプション
 	opts := tmuxpkg.PaneOptions{
-		Split:      "-v", // 垂直分割
+		Split:      "-h", // 水平分割（縦分割）
 		Percentage: 50,   // 50%で分割
 		Title:      phase,
 	}


### PR DESCRIPTION
## 概要
tmuxのpane分割方法を横分割（`-v`）から縦分割（`-h`）に変更しました。これにより、コードレビューや編集作業において画面領域をより効率的に使用できるようになります。

## 関連するIssue
fixes #152

## 変更内容
- `internal/tmux/window.go`: `CreatePaneInWindowWithExecutor`と`SelectOrCreatePaneForPhaseWithExecutor`で使用するsplit-windowコマンドのオプションを`-v`から`-h`に変更
- `internal/watcher/actions/base_executor.go`: `PaneOptions`の`Split`フィールドを`-v`から`-h`に変更
- 関連するテストケースを更新して縦分割を期待するように修正

## テスト結果
- [x] ユニットテスト実行済み（`go test ./...`）
- [x] 静的解析実行済み（`go vet ./...`）
- [x] コードフォーマット実行済み（`go fmt ./...`）

## 動作確認内容
- tmuxのpane分割が縦方向（左右分割）になることを確認
- 既存のpane選択・操作機能が正常に動作することを確認
- 各フェーズ（Plan, Implementation, Review）でpaneが正しく作成されることを確認

## レビューポイント
- split-windowコマンドのオプション変更が適切か
- 影響範囲が最小限に抑えられているか
- テストケースの更新が十分か