### PR TITLE
fix: 新規ウィンドウ作成時のpane分割を無効化

### DIFF
--- a/internal/testutil/mocks/tmux.go
+++ b/internal/testutil/mocks/tmux.go
@@ -198,5 +198,11 @@ func (m *MockTmuxManager) GetPaneByTitle(sessionName, windowName string, title s
 	return args.Get(0).(*tmux.PaneInfo), args.Error(1)
 }
 
+// CreateWindowForIssueWithNewWindowDetection mocks the CreateWindowForIssueWithNewWindowDetection method
+func (m *MockTmuxManager) CreateWindowForIssueWithNewWindowDetection(sessionName string, issueNumber int) (string, bool, error) {
+	args := m.Called(sessionName, issueNumber)
+	return args.String(0), args.Bool(1), args.Error(2)
+}
+
 // Ensure MockTmuxManager implements tmux.Manager interface
 var _ tmux.Manager = (*MockTmuxManager)(nil)

--- a/internal/tmux/init.go
+++ b/internal/tmux/init.go
@@ -106,6 +106,12 @@ func (m *testWindowManager) FindIssueWindow(windowName string) (int, bool) {
 	return 0, false
 }
 
+func (m *testWindowManager) CreateWindowForIssueWithNewWindowDetection(sessionName string, issueNumber int) (string, bool, error) {
+	// テスト環境では常に新規ウィンドウとして扱う
+	windowName := fmt.Sprintf("issue-%d", issueNumber)
+	return windowName, true, nil
+}
+
 // testPaneManager はテスト用のPaneManager実装
 type testPaneManager struct{}
 

--- a/internal/tmux/manager.go
+++ b/internal/tmux/manager.go
@@ -55,6 +55,9 @@ type WindowManager interface {
 
 	// FindIssueWindow ウィンドウ名からIssue番号を抽出
 	FindIssueWindow(windowName string) (int, bool)
+
+	// CreateWindowForIssueWithNewWindowDetection Issue番号に基づいてウィンドウを作成し、新規作成かどうかを返す
+	CreateWindowForIssueWithNewWindowDetection(sessionName string, issueNumber int) (string, bool, error)
 }
 
 // Manager はtmuxの全操作を統合したインターフェース

--- a/internal/tmux/window_manager.go
+++ b/internal/tmux/window_manager.go
@@ -364,3 +364,8 @@ func IsIssueWindow(windowName string) bool {
 	phase := parts[1]
 	return phase == "plan" || phase == "implement" || phase == "review"
 }
+
+// CreateWindowForIssueWithNewWindowDetection Issue番号に基づいてウィンドウを作成し、新規作成かどうかを返す
+func (m *DefaultManager) CreateWindowForIssueWithNewWindowDetection(sessionName string, issueNumber int) (string, bool, error) {
+	return CreateWindowForIssueWithNewWindowDetection(sessionName, issueNumber, m.executor)
+}

--- a/internal/watcher/actions/plan_action_v2_test.go
+++ b/internal/watcher/actions/plan_action_v2_test.go
@@ -39,7 +39,8 @@ func TestPlanActionV2_Execute(t *testing.T) {
 
 				// PrepareWorkspace
 				tmux.On("WindowExists", "test-session", "issue-123").Return(false, nil).Once()
-				tmux.On("CreateWindow", "test-session", "issue-123").Return(nil).Once()
+				tmux.On("CreateWindowForIssueWithNewWindowDetection", "test-session", 123).
+					Return("issue-123", true, nil).Once()
 				git.On("WorktreeExistsForIssue", mock.Anything, 123).Return(false, nil).Once()
 				git.On("CreateWorktreeForIssue", mock.Anything, 123).Return(nil).Once()
 				tmux.On("GetPaneByTitle", "test-session", "issue-123", "Plan").Return(nil, assert.AnError).Once()


### PR DESCRIPTION
## 概要
新規tmuxウィンドウ作成時の自動pane分割を無効化し、既存ウィンドウでのAction実行時のみpane分割を行うように修正しました。

## 関連するIssue
fixes #151

## 変更内容
- `BaseExecutor`で`CreateWindowForIssueWithNewWindowDetection`を使用して新規ウィンドウを判定
- `ensurePane`メソッドに新規ウィンドウフラグを追加し、条件に応じた処理を実装
- 新規ウィンドウの場合：pane分割をスキップして既存のpane 0を使用
- 既存ウィンドウの場合：縦分割（-h）で新しいpaneを作成
- `WindowManager`インターフェースに`CreateWindowForIssueWithNewWindowDetection`メソッドを追加

## テスト結果
- [x] ユニットテスト実行済み（全てパス）
- [x] 統合テスト実行済み
- [x] go fmt実行済み
- [x] go vet実行済み

## 動作確認
### 新規ウィンドウ作成時
- tmuxウィンドウが作成される
- pane分割は行われない
- 単一のpaneでAction（Plan/Implementation/Review）が実行される

### 既存ウィンドウでのAction実行時
- 必要に応じて縦分割でpaneが作成される
- 各フェーズごとに独立したpaneで実行される

## レビューポイント
- `isNewWindow`フラグの受け渡し方法が適切か
- 既存の動作への影響がないか
- テストカバレッジが十分か