### PR TITLE
fix: tmux修正後のworktree操作とClaude実行の機能停止問題の修正

### DIFF
--- a/internal/watcher/actions/base_executor.go
+++ b/internal/watcher/actions/base_executor.go
@@ -175,7 +175,8 @@ func (e *BaseExecutor) ExecuteInWorkspace(workspace *WorkspaceInfo, command stri
 	// worktreeディレクトリに移動してコマンドを実行
 	cdCommand := fmt.Sprintf("cd %s && %s", workspace.WorktreePath, command)
 
-	if err := e.tmuxManager.SendKeys(e.sessionName, workspace.WindowName, cdCommand); err != nil {
+	// RunInWindowを使用してコマンドを実行（自動的にEnterキーが送信される）
+	if err := e.tmuxManager.RunInWindow(e.sessionName, workspace.WindowName, cdCommand); err != nil {
 		return fmt.Errorf("failed to execute command in workspace: %w", err)
 	}
 

--- a/internal/watcher/actions/base_executor_test.go
+++ b/internal/watcher/actions/base_executor_test.go
@@ -257,12 +257,13 @@ func TestBaseExecutor_ExecuteInWorkspace(t *testing.T) {
 			command: "echo 'Hello World'",
 			setupMocks: func(tmux *mocks.MockTmuxManager) {
 				expectedCmd := "cd /test/worktree/issue-123 && echo 'Hello World'"
-				tmux.On("SendKeys", "test-session", "issue-123", expectedCmd).Return(nil).Once()
+				// RunInWindowを使用することを期待
+				tmux.On("RunInWindow", "test-session", "issue-123", expectedCmd).Return(nil).Once()
 			},
 			wantErr: false,
 		},
 		{
-			name: "SendKeys失敗",
+			name: "RunInWindow失敗",
 			workspace: &WorkspaceInfo{
 				WindowName:   "issue-456",
 				WorktreePath: "/test/worktree/issue-456",
@@ -272,7 +273,8 @@ func TestBaseExecutor_ExecuteInWorkspace(t *testing.T) {
 			command: "npm test",
 			setupMocks: func(tmux *mocks.MockTmuxManager) {
 				expectedCmd := "cd /test/worktree/issue-456 && npm test"
-				tmux.On("SendKeys", "test-session", "issue-456", expectedCmd).
+				// RunInWindowを使用することを期待
+				tmux.On("RunInWindow", "test-session", "issue-456", expectedCmd).
 					Return(assert.AnError).Once()
 			},
 			wantErr:     true,

--- a/internal/watcher/actions/plan_action_v2_test.go
+++ b/internal/watcher/actions/plan_action_v2_test.go
@@ -55,7 +55,8 @@ func TestPlanActionV2_Execute(t *testing.T) {
 					mock.Anything,
 				).Return("claude plan command").Once()
 
-				tmux.On("SendKeys", "test-session", "issue-123", "cd /test/worktree/issue-123 && claude plan command").Return(nil).Once()
+				// RunInWindowを使用することを期待
+				tmux.On("RunInWindow", "test-session", "issue-123", "cd /test/worktree/issue-123 && claude plan command").Return(nil).Once()
 
 				// 完了処理
 				state.On("MarkAsCompleted", int64(123), types.IssueStatePlan).Once()


### PR DESCRIPTION
## 概要
tmux修正後、worktree操作とClaude実行が動作しなくなった問題を修正しました。

## 関連するIssue
fixes #155

## 変更内容
- `BaseExecutor.ExecuteInWorkspace`メソッドを`SendKeys`から`RunInWindow`に変更
- これにより自動的にEnterキーが送信され、コマンドが実際に実行されるようになる
- 関連するテストケースも更新

## 根本原因
- `SendKeys`はコマンドをtmuxウィンドウに送信するだけで、Enterキーを送信しない
- そのため、コマンドが入力されるだけで実行されない状態になっていた
- `RunInWindow`は内部でコマンド送信後にEnterキーも送信する実装になっている

## テスト結果
- [x] ユニットテスト実行済み（全てパス）
- [x] go fmt実行済み
- [x] go vet実行済み

## 確認ポイント
- 修正が最小限で、tmux操作の修正内容（新規ウィンドウ作成時のpane分割無効化）は維持されている
- TDDアプローチで実装（テストを先に修正してから実装を修正）