### PR TITLE
fix: osoba cleanコマンドでworktreeも削除するように修正

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -206,3 +206,15 @@ func (w *Worktree) GetMainWorktreePath(ctx context.Context, repoPath string) (st
 
 	return mainPath, nil
 }
+
+// HasUncommittedChanges はworktreeに未コミットの変更があるかを確認する
+func (w *Worktree) HasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	// git status --porcelain を実行
+	output, err := w.command.Run(ctx, "git", []string{"status", "--porcelain"}, worktreePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to check git status: %w", err)
+	}
+
+	// 出力が空でなければ未コミットの変更がある
+	return strings.TrimSpace(output) != "", nil
+}

--- a/internal/testutil/mocks/git_worktree_manager.go
+++ b/internal/testutil/mocks/git_worktree_manager.go
@@ -71,5 +71,23 @@ func (m *MockGitWorktreeManager) RemoveWorktreeForIssue(ctx context.Context, iss
 	return args.Error(0)
 }
 
+// ListWorktreesForIssue mocks the ListWorktreesForIssue method
+func (m *MockGitWorktreeManager) ListWorktreesForIssue(ctx context.Context, issueNumber int) ([]git.WorktreeInfo, error) {
+	args := m.Called(ctx, issueNumber)
+	return args.Get(0).([]git.WorktreeInfo), args.Error(1)
+}
+
+// ListAllWorktrees mocks the ListAllWorktrees method
+func (m *MockGitWorktreeManager) ListAllWorktrees(ctx context.Context) ([]git.WorktreeInfo, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]git.WorktreeInfo), args.Error(1)
+}
+
+// HasUncommittedChanges mocks the HasUncommittedChanges method
+func (m *MockGitWorktreeManager) HasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	args := m.Called(ctx, worktreePath)
+	return args.Bool(0), args.Error(1)
+}
+
 // Ensure MockGitWorktreeManager implements git.WorktreeManager interface
 var _ git.WorktreeManager = (*MockGitWorktreeManager)(nil)


### PR DESCRIPTION
## 概要

`osoba clean`コマンドでworktreeも削除するように修正しました。

## 関連するIssue

fixes #144

## 変更内容

### 主な機能追加

- **worktree削除機能の追加**
  - `osoba clean`コマンドでtmuxウィンドウと同時にworktreeも削除
  - 新旧両方のworktreeパス形式に対応（`.git/worktree/`と`.git/osoba/`）
  - 古い形式：`.git/worktree/{phase}/{issue-number}`
  - 新しい形式：`.git/osoba/worktrees/issue-{issue number}`、`.git/osoba/worktrees/{issue number}-{phase}`

- **--forceオプションの追加**
  - 確認プロンプトを表示せずに削除を実行
  - 未コミット変更がある場合でも強制削除

- **未コミット変更の検出**
  - `git status --porcelain`を使用して未コミット変更を検出
  - 未コミット変更がある場合は警告を表示
  - `--force`オプションなしでは確認プロンプトを表示

### エラーハンドリングの改善

- **部分的削除の対応**
  - ウィンドウ削除が失敗してもworktree削除を試行
  - 各リソースの削除エラーを個別に記録・表示

- **エラー報告の改善**
  - 削除されたリソースと発生したエラーを分けて表示
  - どのリソースが削除され、どのエラーが発生したかを明確に表示

## テスト結果

### 新規テストケース

- [x] worktreeを含むリソース削除のテスト
- [x] 未コミット変更がある場合の確認プロンプト
- [x] 未コミット変更がある場合のキャンセル
- [x] `--force`オプションでの強制削除
- [x] エラー発生時の部分削除

### 既存テストの更新

- [x] 出力フォーマットの変更に対応
- [x] 新しい機能のモック追加

### 全体テスト

- [x] `make test`によるプロジェクト全体のテスト実行
- [x] 既存機能への影響がないことを確認

## 実装の詳細

### 新規メソッド・関数

1. **git/worktree.go**
   - `HasUncommittedChanges`: worktreeに未コミット変更があるかを確認

2. **git/worktree_manager.go**
   - `ListWorktreesForIssue`: 指定されたIssueに関連するworktreeを全て検索
   - `ListAllWorktrees`: 全てのworktreeを検索
   - `HasUncommittedChanges`: worktreeに未コミット変更があるかを確認

3. **cmd/clean.go**
   - `nullLogger`: テスト用のnullロガー実装
   - `createListWorktreesForIssueFunc`: worktree検索関数のファクトリー
   - `createListAllWorktreesFunc`: 全worktree検索関数のファクトリー
   - `createHasUncommittedChangesFunc`: 未コミット変更検出関数のファクトリー
   - `createRemoveWorktreeFunc`: worktree削除関数のファクトリー

### 既存機能の変更

- **`cleanIssueWindows`**: 単一Issue用のクリーンアップ処理を拡張
- **`cleanAllWindows`**: 全Issue用のクリーンアップ処理を拡張
- **コマンド説明**: ウィンドウ削除から「ウィンドウとworktreeの削除」に変更

## 使用例

```bash
# 単一Issueのリソース削除
osoba clean 144

# 全てのリソース削除（確認あり）
osoba clean --all

# 強制削除（確認なし）
osoba clean --force 144

# 全てのリソースを強制削除
osoba clean --all --force
```

## 動作確認

### 削除対象リソースの表示例
```
以下のリソースを削除します:
  ウィンドウ:
    - 144-plan
    - 144-implement
  worktree:
    - /repo/.git/osoba/worktrees/issue-144
```

### 未コミット変更がある場合の警告例
```
警告: 以下のworktreeに未コミットの変更があります:
  - /repo/.git/osoba/worktrees/issue-144
本当に削除しますか？ (yes/no): 
```

🤖 Generated with [Claude Code](https://claude.ai/code)