### PR TITLE
fix: tmux window検出でissue-<number>形式にも対応

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -370,6 +370,9 @@ func (n *nullLogger) WithFields(keysAndValues ...interface{}) logger.Logger {
 
 // テスト時にモック可能な関数変数
 var (
+	checkTmuxInstalledFunc    = tmux.CheckTmuxInstalled
+	getRepositoryNameFunc     = git.GetRepositoryName
+	sessionExistsFunc         = tmux.SessionExists
 	listWindowsForIssueFunc   = tmux.ListWindowsForIssue
 	listWindowsByPatternFunc  = tmux.ListWindowsByPattern
 	killWindowsForIssueFunc   = tmux.KillWindowsForIssue

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/douhashi/osoba/internal/config"
 	"github.com/douhashi/osoba/internal/git"
-	"github.com/douhashi/osoba/internal/tmux"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -122,9 +121,4 @@ func attachToSession(sessionName string) error {
 	return nil
 }
 
-// テスト時にモック可能な関数変数
-var (
-	checkTmuxInstalledFunc = tmux.CheckTmuxInstalled
-	sessionExistsFunc      = tmux.SessionExists
-	getRepositoryNameFunc  = git.GetRepositoryName
-)
+// テスト時にモック可能な関数変数は clean.go で定義されています

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -608,8 +608,11 @@ func ListWindowsForIssueWithExecutor(sessionName string, issueNumber int, execut
 		return nil, fmt.Errorf("issue number must be positive")
 	}
 
-	// Issue番号に関連するウィンドウのパターン（例: "83-plan", "83-implement", "83-review"）
-	pattern := fmt.Sprintf("^%d-", issueNumber)
+	// Issue番号に関連するウィンドウのパターン
+	// 以下のパターンに一致するウィンドウを検索:
+	// - "issue-144" (GetWindowNameで生成されるパターン)
+	// - "144-plan", "144-implement", "144-review" (GetWindowNameWithPhaseで生成されるパターン)
+	pattern := fmt.Sprintf("^(issue-%d|%d-.+)$", issueNumber, issueNumber)
 	return ListWindowsByPatternWithExecutor(sessionName, pattern, executor)
 }
 

--- a/internal/tmux/window_clean_test.go
+++ b/internal/tmux/window_clean_test.go
@@ -139,7 +139,7 @@ func TestListWindowsForIssue(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:        "正常系: Issue番号83のウィンドウを取得",
+			name:        "正常系: Issue番号83のウィンドウを取得（フェーズ形式）",
 			sessionName: "test-session",
 			issueNumber: 83,
 			windowList: `0:main:0:1
@@ -148,6 +148,29 @@ func TestListWindowsForIssue(t *testing.T) {
 3:83-review:0:1
 4:84-plan:0:1`,
 			expectedNames: []string{"83-plan", "83-implement", "83-review"},
+			expectedError: false,
+		},
+		{
+			name:        "正常系: Issue番号144のウィンドウを取得（issue-形式）",
+			sessionName: "test-session",
+			issueNumber: 144,
+			windowList: `0:main:0:1
+1:issue-144:0:1
+2:145-plan:0:1
+3:issue-146:0:1`,
+			expectedNames: []string{"issue-144"},
+			expectedError: false,
+		},
+		{
+			name:        "正常系: Issue番号83のウィンドウを取得（混在形式）",
+			sessionName: "test-session",
+			issueNumber: 83,
+			windowList: `0:main:0:1
+1:issue-83:0:1
+2:83-plan:0:1
+3:83-implement:1:1
+4:84-plan:0:1`,
+			expectedNames: []string{"issue-83", "83-plan", "83-implement"},
 			expectedError: false,
 		},
 		{


### PR DESCRIPTION
## 概要
`osoba clean`コマンドでtmuxウィンドウが削除されない問題を修正しました。

## 関連するIssue
cleanコマンドで worktree の削除は行われるが、tmux windowの削除が行われない問題の修正。

## 変更内容
- `ListWindowsForIssueWithExecutor`関数の正規表現パターンを修正し、`issue-<number>`形式と`<number>-<phase>`形式の両方に対応
- `window_clean_test.go`に両パターンのテストケースを追加
- `clean.go`に不足していた関数変数定義を追加
- `open.go`から重複した関数変数定義を削除

## 問題の詳細
### 修正前の問題
- `ListWindowsForIssue`関数が`^<number>-`パターンのみを検索
- 実際のウィンドウ名`issue-144`が見つからない

### 修正後の解決
- 正規表現パターンを`^(issue-%d|%d-.+)$`に変更
- 両方の命名規則に対応：
  - `issue-144` (GetWindowNameで生成)
  - `144-plan`, `144-implement`, `144-review` (GetWindowNameWithPhaseで生成)

## テスト結果
- [x] 全テストが通過
- [x] `osoba clean 144`でissue-144ウィンドウが正常に削除される
- [x] 両方のウィンドウ命名パターンが適切に検出される

## レビューポイント
- 正規表現パターンの妥当性
- テストケースの網羅性
- 既存機能への影響がないか

🤖 Generated with [Claude Code](https://claude.ai/code)