### PR TITLE
docs: README.mdのインストール手順を修正 (#161)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,6 @@ archives:
   - id: osoba
     name_template: >-
       {{ .ProjectName }}_
-      {{- .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/README.md
+++ b/README.md
@@ -50,13 +50,24 @@ gh auth login
 最新のリリース版は[GitHub Releases](https://github.com/douhashi/osoba/releases)からダウンロードできます。
 
 ```bash
-# Linux (amd64)
-curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_Linux_x86_64.tar.gz | tar xz
+# Linux (x86_64)
+curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_linux_x86_64.tar.gz | tar xz
 sudo mv osoba /usr/local/bin/
 
-# macOS (Apple Silicon)
-curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_Darwin_arm64.tar.gz | tar xz
+# Linux (ARM64)
+curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_linux_arm64.tar.gz | tar xz
 sudo mv osoba /usr/local/bin/
+
+# macOS (x86_64 / Intel)
+curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_darwin_x86_64.tar.gz | tar xz
+sudo mv osoba /usr/local/bin/
+
+# macOS (ARM64 / Apple Silicon)
+curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_darwin_arm64.tar.gz | tar xz
+sudo mv osoba /usr/local/bin/
+
+# ワンライナーインストール（自動判定）
+curl -L https://github.com/douhashi/osoba/releases/latest/download/osoba_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/x86_64/; s/aarch64/arm64/').tar.gz | tar xz && sudo mv osoba /usr/local/bin/
 ```
 
 ### ソースからのビルド


### PR DESCRIPTION
## 概要
README.mdのインストール手順を修正し、GoReleaserの設定を更新しました。

## 関連するIssue
fixes #161

## 変更内容
- **GoReleaser設定の変更**: `.goreleaser.yml`からバージョン情報を除去してシンプルなファイル名に変更
- **README.mdの修正**: 正しいアセット名に合わせたインストール手順に更新
- **プラットフォーム対応**: Linux/macOSの各アーキテクチャ（x86_64、ARM64）対応
- **ワンライナーインストール**: uname系コマンドを使用した自動判定インストール手順を追加

## 変更前後の比較

### ファイル名の変更
**Before:** `osoba_0.5.0_linux_x86_64.tar.gz`
**After:** `osoba_linux_x86_64.tar.gz`

### インストール手順の改善
- 全プラットフォーム対応（Linux/macOS × x86_64/ARM64）
- ワンライナーインストール手順を追加
- より明確な説明とコメント

## 利点
- シンプルなURL（バージョン情報を含まない）
- 常に最新版を指すURLの提供
- ワンライナーでのインストールが可能

## テスト結果
- [x] 変更内容の確認済み
- [x] コミットメッセージの確認済み
- [x] プレコミットフックの実行済み

## 影響範囲
- 次のリリースから新しいファイル名規則が適用
- 既存のインストール手順が改善

🤖 Generated with [Claude Code](https://claude.ai/code)