### PR TITLE
feat: osoba stopで完全クリーンアップ機能を追加

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os/exec"
 
 	"github.com/douhashi/osoba/internal/daemon"
 	"github.com/douhashi/osoba/internal/paths"
+	"github.com/douhashi/osoba/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +25,11 @@ func newStopCmd() *cobra.Command {
 }
 
 // テスト用にモック可能な関数変数
-var stopProcessFunc = stopProcess
+var (
+	stopProcessFunc     = stopProcess
+	performCleanupFunc  = performCleanup
+	killTmuxSessionFunc = killTmuxSession
+)
 
 func runStop(cmd *cobra.Command, args []string) error {
 	// リポジトリ識別子を取得
@@ -32,16 +38,51 @@ func runStop(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// リポジトリ名を取得（クリーンアップとtmuxセッション削除に使用）
+	repoName, err := getRepositoryNameFunc()
+	if err != nil {
+		return fmt.Errorf("リポジトリ名の取得に失敗: %w", err)
+	}
+
 	// パスマネージャを作成
 	pm := paths.NewPathManager("")
 	pidFile := pm.PIDFile(repoIdentifier)
 
-	// プロセスを停止
+	// エラーを収集（部分的失敗時でも処理を継続）
+	var errors []error
+
+	// 1. プロセスを停止
 	if err := stopProcessFunc(pidFile); err != nil {
-		return err
+		errors = append(errors, fmt.Errorf("プロセス停止に失敗: %w", err))
+		fmt.Fprintf(cmd.OutOrStderr(), "プロセス停止に失敗しましたが、クリーンアップを継続します: %v\n", err)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Issue監視を停止しました。\n")
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Issue監視を停止しました。\n")
+	// 2. クリーンアップ処理（clean --all --force 相当）
+	sessionName := fmt.Sprintf("osoba-%s", repoName)
+	if err := performCleanupFunc(sessionName); err != nil {
+		errors = append(errors, fmt.Errorf("クリーンアップに失敗: %w", err))
+		fmt.Fprintf(cmd.OutOrStderr(), "クリーンアップに失敗しましたが、tmux削除を継続します: %v\n", err)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "クリーンアップが完了しました。\n")
+	}
+
+	// 3. tmuxセッションを削除
+	if err := killTmuxSessionFunc(sessionName); err != nil {
+		errors = append(errors, fmt.Errorf("tmuxセッション削除に失敗: %w", err))
+		fmt.Fprintf(cmd.OutOrStderr(), "tmuxセッション削除に失敗しました: %v\n", err)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "tmuxセッションを削除しました。\n")
+	}
+
+	// 最終メッセージ
+	if len(errors) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "停止処理が完了しました。\n")
+	} else {
+		fmt.Fprintf(cmd.OutOrStderr(), "停止処理が完了しましたが、%d個のエラーが発生しました。\n", len(errors))
+	}
+
 	return nil
 }
 
@@ -65,4 +106,49 @@ func stopProcess(pidFile string) error {
 	}
 
 	return nil
+}
+
+// performCleanup は clean --all --force 相当の処理を実行します
+func performCleanup(sessionName string) error {
+	return performCleanupAllForce(sessionName)
+}
+
+// killTmuxSession は指定されたtmuxセッションを削除します
+func killTmuxSession(sessionName string) error {
+	// tmuxがインストールされているか確認
+	if err := tmux.CheckTmuxInstalled(); err != nil {
+		return fmt.Errorf("tmuxが利用できません: %w", err)
+	}
+
+	// セッションが存在するか確認
+	exists, err := tmux.SessionExists(sessionName)
+	if err != nil {
+		return fmt.Errorf("セッション存在確認に失敗: %w", err)
+	}
+
+	if !exists {
+		// セッションが存在しない場合は正常終了（削除済みと見なす）
+		return nil
+	}
+
+	// セッションを削除（kill-sessionコマンドを直接実行）
+	if err := killSessionWithCommand(sessionName); err != nil {
+		return fmt.Errorf("セッション削除に失敗: %w", err)
+	}
+
+	return nil
+}
+
+// killSessionWithCommand はtmux kill-sessionコマンドを実行します
+func killSessionWithCommand(sessionName string) error {
+	cmd := stopExecCommand("tmux", "kill-session", "-t", sessionName)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("tmuxコマンド実行失敗: %w", err)
+	}
+	return nil
+}
+
+// テスト用にstopExecCommandを定義
+var stopExecCommand = func(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
 }


### PR DESCRIPTION
## Summary
Issue #164 の要件に従い、`osoba stop`コマンドに完全なクリーンアップ機能を追加しました。

### 主な変更点
- プロセス停止後に`clean --all --force`相当の処理を自動実行
- 対象リポジトリのtmuxセッションを自動削除
- 部分的失敗時でも可能な限り処理を継続するエラーハンドリング
- 各ステップでの適切なログ出力とユーザーフィードバック

### 技術的な改善
- `performCleanupAllForce`関数を新設してcleanロジックを再利用可能に
- テストファーストでの新機能実装
- 既存テストを新しい動作に合わせて更新

## Test plan
- [ ] 全テストがパスすることを確認済み
- [ ] 新機能のテストケースを追加
- [ ] 既存の動作に影響しないことを確認
- [ ] エラーケースでの部分的継続処理を確認

### 実装の詳細
1. **プロセス停止**: 従来通りのプロセス停止処理
2. **クリーンアップ**: git worktreeとログファイルの削除
3. **tmuxセッション削除**: 対象リポジトリのセッションを自動削除
4. **エラーハンドリング**: 各ステップで失敗しても処理を継続

### 受け入れ条件の確認
- [x] `osoba stop`実行時にプロセス停止処理を実行
- [x] `clean --all --force`相当のクリーンアップ処理を自動実行
- [x] 対象リポジトリのtmuxセッションが存在するかチェック
- [x] セッションが存在する場合は自動的に削除（kill-session）
- [x] 各ステップでの適切なログ出力とエラーハンドリング
- [x] 他のリポジトリのリソースには影響しない
- [x] 部分的失敗時でも可能な限り処理を継続

🤖 Generated with [Claude Code](https://claude.ai/code)