### PR TITLE
feat: osoba startコマンドの実行フィードバック機能追加

### DIFF
--- a/internal/daemon/daemon_common.go
+++ b/internal/daemon/daemon_common.go
@@ -46,6 +46,11 @@ func WritePIDFile(pidFile string, info *ProcessInfo) error {
 	return nil
 }
 
+// ReadPIDFile は外部から呼び出し可能なPIDファイル読み込み関数
+func ReadPIDFile(pidFile string) (*ProcessInfo, error) {
+	return readPIDFile(pidFile)
+}
+
 // readPIDFile はPIDファイルを読み込みます
 func readPIDFile(pidFile string) (*ProcessInfo, error) {
 	content, err := os.ReadFile(pidFile)


### PR DESCRIPTION
## 概要
`osoba start`コマンドの実行フィードバック機能を追加しました。バックグラウンド実行時に設定情報や実行状況を表示し、ユーザーが実行されたかどうかを確認できるようになりました。

## 関連するIssue
fixes #168

## 変更内容
- **startInBackground関数の改善**: バックグラウンド実行時に詳細なフィードバックメッセージを表示
- **設定情報の表示**: ポーリング間隔、リポジトリ情報、設定ファイル情報を実行時に表示
- **エラーメッセージの向上**: 既に実行中の場合にPID情報を含む詳細なメッセージを表示
- **ReadPIDFile関数の追加**: daemon_common.goに外部から呼び出し可能な関数を追加
- **テストケースの追加**: バックグラウンド実行時のフィードバック表示をテスト

## 実装詳細

### バックグラウンド実行時のフィードバック表示
- 「Issue監視を開始しています...」から始まる段階的な情報表示
- リポジトリ情報 (owner/repo形式)
- ポーリング間隔の設定値
- 使用している設定ファイルのパス（指定ファイル/デフォルト/なし）
- 成功時のPID表示

### エラーケースの改善
- 既に実行中の場合にPID情報を含む詳細メッセージ
- PIDファイルから既存プロセス情報を読み取り

## テスト結果
- [x] 全ユニットテスト実行済み (make test)
- [x] バックグラウンド実行フィードバック表示テスト追加
- [x] 既に実行中の場合のメッセージテスト追加
- [x] コードフォーマット確認済み (go fmt, goimports)

## 受け入れ条件の達成状況
- [x] `osoba start`実行時に開始処理の状況を表示
- [x] 成功時は「開始しました」などの成功メッセージを表示
- [x] 監視インターバル（ポーリング間隔）の情報を表示
- [x] 監視対象のリポジトリ情報（owner/repo）を表示
- [x] プロセスID（PID）やセッション名などの有用な情報を表示
- [x] 失敗時は適切なエラーメッセージを表示
- [x] 既に実行中の場合は「既に実行中です」などの状況メッセージを表示
- [x] バックグラウンド実行でも適切にメッセージが表示される

## レビューポイント
- startInBackground関数での設定情報取得とメッセージ表示ロジック
- エラーケースでのPID情報表示の実装
- テストケースの妥当性とテスト方法

## 動作確認
バックグラウンド実行時に以下のようなフィードバックが表示されます：

```
Issue監視を開始しています...
リポジトリ: douhashi/osoba
ポーリング間隔: 5s
設定ファイル: /path/to/config.yml (デフォルト)
バックグラウンドで起動しました
PID: 12345
```

既に実行中の場合：
```
Issue監視を開始しています...
リポジトリ: douhashi/osoba
Error: 既に実行中です (PID: 9999)
```