### PR TITLE
fix: tmuxのpane-base-index設定に対応

### DIFF
--- a/internal/testutil/mocks/tmux.go
+++ b/internal/testutil/mocks/tmux.go
@@ -198,6 +198,12 @@ func (m *MockTmuxManager) GetPaneByTitle(sessionName, windowName string, title s
 	return args.Get(0).(*tmux.PaneInfo), args.Error(1)
 }
 
+// GetPaneBaseIndex mocks the GetPaneBaseIndex method
+func (m *MockTmuxManager) GetPaneBaseIndex() (int, error) {
+	args := m.Called()
+	return args.Int(0), args.Error(1)
+}
+
 // CreateWindowForIssueWithNewWindowDetection mocks the CreateWindowForIssueWithNewWindowDetection method
 func (m *MockTmuxManager) CreateWindowForIssueWithNewWindowDetection(sessionName string, issueNumber int) (string, bool, error) {
 	args := m.Called(sessionName, issueNumber)

--- a/internal/tmux/init.go
+++ b/internal/tmux/init.go
@@ -14,6 +14,12 @@ type MockManager struct {
 	PaneManager
 }
 
+// GetPaneBaseIndex テスト用のpane-base-index取得
+func (m *MockManager) GetPaneBaseIndex() (int, error) {
+	// テスト環境では0を返す
+	return 0, nil
+}
+
 // createTestMockManager はテスト用のモックマネージャーを作成
 func createTestMockManager() Manager {
 	return &MockManager{

--- a/internal/tmux/manager_pane.go
+++ b/internal/tmux/manager_pane.go
@@ -55,9 +55,10 @@ func (m *DefaultManager) SelectPane(sessionName, windowName string, paneIndex in
 // SetPaneTitle ペインのタイトルを設定
 func (m *DefaultManager) SetPaneTitle(sessionName, windowName string, paneIndex int, title string) error {
 	// ペインのボーダーフォーマットを設定
-	args := []string{"set-option", "-t", fmt.Sprintf("%s:%s.%d", sessionName, windowName, paneIndex), "-p", "pane-border-format", fmt.Sprintf(" %s ", title)}
+	target := fmt.Sprintf("%s:%s.%d", sessionName, windowName, paneIndex)
+	args := []string{"set-option", "-t", target, "-p", "pane-border-format", fmt.Sprintf(" %s ", title)}
 	if _, err := m.executor.Execute("tmux", args...); err != nil {
-		return fmt.Errorf("failed to set pane title: %w", err)
+		return fmt.Errorf("failed to set pane title for %s: %w", target, err)
 	}
 	return nil
 }

--- a/internal/watcher/actions/base_executor.go
+++ b/internal/watcher/actions/base_executor.go
@@ -143,12 +143,22 @@ func (e *BaseExecutor) ensurePane(windowName string, phase string, isNewWindow b
 	// 新規ウィンドウの場合は、pane分割せずに既存のpane 0を使用
 	if isNewWindow {
 		e.logger.Info("Using existing pane for new window", "phase", phase)
-		// 既存のpane 0のタイトルを設定
-		if err := e.tmuxManager.SetPaneTitle(e.sessionName, windowName, 0, phase); err != nil {
+
+		// pane-base-indexを取得
+		baseIndex, err := e.tmuxManager.GetPaneBaseIndex()
+		if err != nil {
+			// エラーの場合はデフォルト値の0を使用
+			e.logger.Warn("Failed to get pane-base-index, using default 0", "error", err)
+			baseIndex = 0
+		}
+		e.logger.Info("Got pane-base-index", "baseIndex", baseIndex)
+
+		// 既存のpaneのタイトルを設定
+		if err := e.tmuxManager.SetPaneTitle(e.sessionName, windowName, baseIndex, phase); err != nil {
 			return nil, fmt.Errorf("failed to set pane title: %w", err)
 		}
 		return &tmuxpkg.PaneInfo{
-			Index:  0,
+			Index:  baseIndex,
 			Title:  phase,
 			Active: true,
 		}, nil
@@ -164,12 +174,21 @@ func (e *BaseExecutor) ensurePane(windowName string, phase string, isNewWindow b
 
 	// 最初のフェーズ（Plan）の場合は、既存のpane（index 0）を使用
 	if phase == "Plan" {
-		// 既存のpane 0のタイトルを設定
-		if err := e.tmuxManager.SetPaneTitle(e.sessionName, windowName, 0, phase); err != nil {
+		// pane-base-indexを取得
+		baseIndex, err := e.tmuxManager.GetPaneBaseIndex()
+		if err != nil {
+			// エラーの場合はデフォルト値の0を使用
+			e.logger.Warn("Failed to get pane-base-index, using default 0", "error", err)
+			baseIndex = 0
+		}
+		e.logger.Info("Got pane-base-index", "baseIndex", baseIndex)
+
+		// 既存のpaneのタイトルを設定
+		if err := e.tmuxManager.SetPaneTitle(e.sessionName, windowName, baseIndex, phase); err != nil {
 			return nil, fmt.Errorf("failed to set pane title: %w", err)
 		}
 		return &tmuxpkg.PaneInfo{
-			Index:  0,
+			Index:  baseIndex,
 			Title:  phase,
 			Active: true,
 		}, nil

--- a/internal/watcher/actions/base_executor_test.go
+++ b/internal/watcher/actions/base_executor_test.go
@@ -51,6 +51,8 @@ func TestBaseExecutor_PrepareWorkspace(t *testing.T) {
 				// Pane検索（なし）
 				tmux.On("GetPaneByTitle", "test-session", "issue-111", "Plan").
 					Return(nil, assert.AnError).Once()
+				// pane-base-index取得
+				tmux.On("GetPaneBaseIndex").Return(0, nil).Once()
 				// Pane 0のタイトル設定のみ
 				tmux.On("SetPaneTitle", "test-session", "issue-111", 0, "Plan").Return(nil).Once()
 
@@ -91,6 +93,8 @@ func TestBaseExecutor_PrepareWorkspace(t *testing.T) {
 				// Pane検索（なし）
 				tmux.On("GetPaneByTitle", "test-session", "issue-123", "Plan").
 					Return(nil, assert.AnError).Once()
+				// pane-base-index取得
+				tmux.On("GetPaneBaseIndex").Return(0, nil).Once()
 				// Pane 0のタイトル設定のみ
 				tmux.On("SetPaneTitle", "test-session", "issue-123", 0, "Plan").Return(nil).Once()
 
@@ -205,6 +209,8 @@ func TestBaseExecutor_PrepareWorkspace(t *testing.T) {
 				// Pane検索（なし）
 				tmux.On("GetPaneByTitle", "test-session", "issue-888", "Implementation").
 					Return(nil, assert.AnError).Once()
+				// pane-base-index取得
+				tmux.On("GetPaneBaseIndex").Return(0, nil).Once()
 				// Pane 0のタイトル設定のみ
 				tmux.On("SetPaneTitle", "test-session", "issue-888", 0, "Implementation").Return(nil).Once()
 

--- a/internal/watcher/actions/plan_action_test.go
+++ b/internal/watcher/actions/plan_action_test.go
@@ -45,6 +45,7 @@ func TestPlanActionV2_Execute(t *testing.T) {
 				git.On("WorktreeExistsForIssue", mock.Anything, 123).Return(false, nil).Once()
 				git.On("CreateWorktreeForIssue", mock.Anything, 123).Return(nil).Once()
 				tmux.On("GetPaneByTitle", "test-session", "issue-123", "Plan").Return(nil, assert.AnError).Once()
+				tmux.On("GetPaneBaseIndex").Return(0, nil).Once()
 				tmux.On("SetPaneTitle", "test-session", "issue-123", 0, "Plan").Return(nil).Once()
 				git.On("GetWorktreePathForIssue", 123).Return("/test/worktree/issue-123").Once()
 
@@ -138,6 +139,7 @@ func TestPlanActionV2_Execute(t *testing.T) {
 				tmux.On("WindowExists", "test-session", "issue-999").Return(true, nil).Once()
 				git.On("WorktreeExistsForIssue", mock.Anything, 999).Return(true, nil).Once()
 				tmux.On("GetPaneByTitle", "test-session", "issue-999", "Plan").Return(nil, assert.AnError).Once()
+				tmux.On("GetPaneBaseIndex").Return(0, nil).Once()
 				tmux.On("SetPaneTitle", "test-session", "issue-999", 0, "Plan").Return(nil).Once()
 				git.On("GetWorktreePathForIssue", 999).Return("/test/worktree/issue-999").Once()
 


### PR DESCRIPTION
## 概要
tmuxのpane-base-indexが1に設定されている環境で、paneタイトル設定が失敗する問題を修正しました。

## 関連するIssue
fixes #179

## 変更内容
### 1. tmux.Managerインターフェースの拡張
- `GetPaneBaseIndex()` メソッドを追加
- tmuxの`pane-base-index`設定を動的に取得できるように

### 2. base_executorの修正
- 新規ウィンドウ作成時とPlanフェーズでpaneタイトルを設定する際に、`GetPaneBaseIndex()`を呼び出してインデックスを取得
- ハードコードされていた`0`の代わりに、取得したインデックスを使用
- デバッグログを追加して問題の診断を容易に

### 3. エラーメッセージの改善
- `SetPaneTitle`のエラーメッセージにターゲット情報を含めるように修正
- エラー時のデバッグが容易になりました

### 4. テストケースの更新
- 新しい`GetPaneBaseIndex`メソッドのモックを追加
- 既存のテストケースを更新

## テスト結果
- [x] ユニットテスト実行済み
- [x] 実環境でのテスト実行済み（pane-base-index=1の環境）
- [x] go fmt/vet実行済み

## 動作確認
```bash
# tmuxのpane-base-indexを確認
tmux show-options -g pane-base-index
# pane-base-index 1

# osobaを起動してIssue処理を確認
./osoba start --foreground
# 正常にpaneタイトルが設定され、Claude実行まで進むことを確認
```

## レビューポイント
- `GetPaneBaseIndex()`でエラーが発生した場合、デフォルト値の0を返す実装になっています。これは多くの環境で適切な動作を保証するためです。
- デバッグログを追加していますが、本番環境での影響は最小限です。
EOF < /dev/null