### PR TITLE
feat: osoba start実行時の設定ファイル存在チェック機能の追加 (#187)

### DIFF
--- a/cmd/start_config_integration_test.go
+++ b/cmd/start_config_integration_test.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/douhashi/osoba/internal/testutil/helpers"
+	"github.com/spf13/cobra"
+)
+
+func TestStartCmd_ConfigFileCheck(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// 元の環境変数を保存
+	origHome := os.Getenv("HOME")
+	origXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+
+	// テスト用の環境変数を設定
+	os.Setenv("HOME", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("XDG_CONFIG_HOME", origXDGConfigHome)
+	}()
+
+	tests := []struct {
+		name               string
+		setupFiles         func()
+		setupEnv           func()
+		setupGitRepo       func(t *testing.T) (string, func())
+		args               []string
+		wantErr            bool
+		wantErrContains    string
+		wantOutputContains []string
+	}{
+		{
+			name: "設定ファイルが存在しない場合、エラーメッセージが表示される",
+			setupFiles: func() {
+				// 設定ファイルを作成しない
+			},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			setupGitRepo: func(t *testing.T) (string, func()) {
+				// Gitリポジトリを作成
+				gitDir := filepath.Join(tmpDir, "test-repo")
+				os.MkdirAll(gitDir, 0755)
+
+				cmd := exec.Command("git", "init")
+				cmd.Dir = gitDir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git init failed: %v", err)
+				}
+
+				cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/douhashi/test-repo.git")
+				cmd.Dir = gitDir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git remote add failed: %v", err)
+				}
+
+				cleanup := func() {
+					os.RemoveAll(gitDir)
+				}
+
+				return gitDir, cleanup
+			},
+			args:            []string{"start", "--foreground"},
+			wantErr:         true,
+			wantErrContains: "設定ファイルが見つかりません",
+			wantOutputContains: []string{
+				"エラー: 設定ファイルが見つかりません",
+				"osoba init",
+			},
+		},
+		{
+			name: "helpフラグの場合は設定ファイルチェックをスキップ",
+			setupFiles: func() {
+				// 設定ファイルを作成しない
+			},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			setupGitRepo: func(t *testing.T) (string, func()) {
+				// Gitリポジトリを作成
+				gitDir := filepath.Join(tmpDir, "test-repo")
+				os.MkdirAll(gitDir, 0755)
+
+				cmd := exec.Command("git", "init")
+				cmd.Dir = gitDir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git init failed: %v", err)
+				}
+
+				cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/douhashi/test-repo.git")
+				cmd.Dir = gitDir
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("git remote add failed: %v", err)
+				}
+
+				cleanup := func() {
+					os.RemoveAll(gitDir)
+				}
+
+				return gitDir, cleanup
+			},
+			args:    []string{"start", "--help"},
+			wantErr: false,
+			wantOutputContains: []string{
+				"Usage:",
+				"osoba start",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// クリーンアップ
+			os.RemoveAll(filepath.Join(tmpDir, ".config"))
+			os.RemoveAll(filepath.Join(tmpDir, "xdg"))
+			os.Remove(filepath.Join(tmpDir, ".osoba.yml"))
+			os.Remove(filepath.Join(tmpDir, ".osoba.yaml"))
+
+			// テスト環境のセットアップ
+			tt.setupFiles()
+			tt.setupEnv()
+
+			// Gitリポジトリのセットアップ
+			dir, cleanup := tt.setupGitRepo(t)
+			defer cleanup()
+
+			// 現在のディレクトリを保存して、テスト後に戻す
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Chdir(origDir)
+
+			// テスト用ディレクトリに移動
+			err = os.Chdir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// コマンドを実行
+			buf := new(bytes.Buffer)
+			errBuf := new(bytes.Buffer)
+
+			rootCmd := newRootCmd()
+			rootCmd.AddCommand(newStartCmd())
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(errBuf)
+			rootCmd.SetArgs(tt.args)
+
+			err = rootCmd.Execute()
+
+			// エラーチェック
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// エラーメッセージのチェック
+			if tt.wantErrContains != "" {
+				errOutput := errBuf.String()
+				if !bytes.Contains([]byte(errOutput), []byte(tt.wantErrContains)) {
+					t.Errorf("Execute() error output = %v, want to contain %v", errOutput, tt.wantErrContains)
+				}
+			}
+
+			// 出力内容のチェック
+			output := buf.String() + errBuf.String()
+			for _, want := range tt.wantOutputContains {
+				if !bytes.Contains([]byte(output), []byte(want)) {
+					t.Errorf("Execute() output = %v, want to contain %v", output, want)
+				}
+			}
+		})
+	}
+}
+
+func TestStartCmd_BackgroundMode_ConfigFileCheck(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// 元の環境変数を保存
+	origHome := os.Getenv("HOME")
+	origXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+
+	// テスト用の環境変数を設定
+	os.Setenv("HOME", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("XDG_CONFIG_HOME", origXDGConfigHome)
+	}()
+
+	// Gitリポジトリを作成
+	gitDir := filepath.Join(tmpDir, "test-repo")
+	os.MkdirAll(gitDir, 0755)
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = gitDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git init failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "remote", "add", "origin", "https://github.com/douhashi/test-repo.git")
+	cmd.Dir = gitDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git remote add failed: %v", err)
+	}
+
+	// 現在のディレクトリを保存して、テスト後に戻す
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	// テスト用ディレクトリに移動
+	err = os.Chdir(gitDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// モックのセットアップ
+	mocker := helpers.NewFunctionMocker()
+	defer mocker.Restore()
+
+	// バックグラウンドモードのテスト（設定ファイルなし）
+	t.Run("バックグラウンドモードで設定ファイルが存在しない場合", func(t *testing.T) {
+		os.Unsetenv("XDG_CONFIG_HOME")
+
+		// startInBackgroundをモックして実際のバックグラウンド実行を防ぐ
+		backgroundCalled := false
+		mocker.MockFunc(&startInBackgroundFunc, func(cmd *cobra.Command, args []string) error {
+			backgroundCalled = true
+			// 設定ファイルチェックはstartInBackground内で行われる
+			return checkConfigFileExists(cmd.OutOrStderr())
+		})
+
+		// コマンドを実行
+		buf := new(bytes.Buffer)
+		errBuf := new(bytes.Buffer)
+
+		rootCmd := newRootCmd()
+		rootCmd.AddCommand(newStartCmd())
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(errBuf)
+		rootCmd.SetArgs([]string{"start"})
+
+		err := rootCmd.Execute()
+
+		// エラーが発生することを確認
+		if err == nil {
+			t.Error("Expected error when config file not found, but got nil")
+		}
+
+		// エラーメッセージを確認
+		errOutput := errBuf.String()
+		if !bytes.Contains([]byte(errOutput), []byte("設定ファイルが見つかりません")) {
+			t.Errorf("Expected error message containing '設定ファイルが見つかりません', got: %v", errOutput)
+		}
+
+		// バックグラウンド関数が呼ばれたことを確認
+		if !backgroundCalled {
+			t.Error("startInBackground was not called")
+		}
+	})
+}

--- a/cmd/start_config_test.go
+++ b/cmd/start_config_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/douhashi/osoba/internal/testutil/helpers"
+)
+
+func TestCheckConfigFileExists(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// 元の環境変数を保存
+	origHome := os.Getenv("HOME")
+	origXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+
+	// テスト用の環境変数を設定
+	os.Setenv("HOME", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("XDG_CONFIG_HOME", origXDGConfigHome)
+	}()
+
+	tests := []struct {
+		name            string
+		setupFiles      func()
+		setupEnv        func()
+		mockStat        func(*helpers.FunctionMocker)
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "設定ファイルが存在する場合",
+			setupFiles: func() {
+				configDir := filepath.Join(tmpDir, ".config", "osoba")
+				os.MkdirAll(configDir, 0755)
+				configFile := filepath.Join(configDir, "osoba.yml")
+				os.WriteFile(configFile, []byte("test"), 0644)
+			},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			wantErr: false,
+		},
+		{
+			name: "設定ファイルが存在しない場合",
+			setupFiles: func() {
+				// 何もしない（ファイルを作成しない）
+			},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			wantErr:         true,
+			wantErrContains: "設定ファイルが見つかりません",
+		},
+		{
+			name: "XDG_CONFIG_HOMEに設定ファイルが存在する場合",
+			setupFiles: func() {
+				xdgDir := filepath.Join(tmpDir, "xdg")
+				configDir := filepath.Join(xdgDir, "osoba")
+				os.MkdirAll(configDir, 0755)
+				configFile := filepath.Join(configDir, "osoba.yml")
+				os.WriteFile(configFile, []byte("test"), 0644)
+			},
+			setupEnv: func() {
+				os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+			},
+			wantErr: false,
+		},
+		{
+			name:       "ホームディレクトリの取得に失敗した場合",
+			setupFiles: func() {},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			mockStat: func(mocker *helpers.FunctionMocker) {
+				// os.UserHomeDirをモックして失敗させる
+				mocker.MockFunc(&osUserHomeDirFunc, func() (string, error) {
+					return "", errors.New("home directory not found")
+				})
+			},
+			wantErr:         true,
+			wantErrContains: "設定ファイルが見つかりません",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// クリーンアップ
+			os.RemoveAll(filepath.Join(tmpDir, ".config"))
+			os.RemoveAll(filepath.Join(tmpDir, "xdg"))
+			os.Remove(filepath.Join(tmpDir, ".osoba.yml"))
+			os.Remove(filepath.Join(tmpDir, ".osoba.yaml"))
+
+			// モッカーのセットアップ
+			mocker := helpers.NewFunctionMocker()
+			defer mocker.Restore()
+
+			tt.setupFiles()
+			tt.setupEnv()
+
+			if tt.mockStat != nil {
+				tt.mockStat(mocker)
+			}
+
+			errBuf := new(bytes.Buffer)
+			err := checkConfigFileExists(errBuf)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkConfigFileExists() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErrContains != "" {
+				errOutput := errBuf.String()
+				if !bytes.Contains([]byte(errOutput), []byte(tt.wantErrContains)) {
+					t.Errorf("checkConfigFileExists() error output = %v, want to contain %v", errOutput, tt.wantErrContains)
+				}
+			}
+		})
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/douhashi/osoba/internal/utils"
 )
@@ -16,4 +18,47 @@ func getRepoIdentifier() (string, error) {
 	}
 
 	return fmt.Sprintf("%s-%s", repoInfo.Owner, repoInfo.Repo), nil
+}
+
+// getConfigFilePaths は設定ファイルの候補パスを優先順位順に返します
+func getConfigFilePaths() []string {
+	var paths []string
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// エラーが発生した場合は空のスライスを返す
+		return paths
+	}
+
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome != "" {
+		// XDG_CONFIG_HOMEが設定されている場合
+		paths = append(paths,
+			filepath.Join(xdgConfigHome, "osoba", "osoba.yml"),
+			filepath.Join(xdgConfigHome, "osoba", "osoba.yaml"),
+		)
+	}
+
+	// デフォルトのパス
+	paths = append(paths,
+		filepath.Join(home, ".config", "osoba", "osoba.yml"),
+		filepath.Join(home, ".config", "osoba", "osoba.yaml"),
+		filepath.Join(home, ".osoba.yml"),
+		filepath.Join(home, ".osoba.yaml"),
+	)
+
+	return paths
+}
+
+// findConfigFile は実際に存在する設定ファイルのパスを返します
+func findConfigFile() (string, bool) {
+	paths := getConfigFilePaths()
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			return path, true
+		}
+	}
+
+	return "", false
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetConfigFilePaths(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// 元のHOME環境変数を保存
+	origHome := os.Getenv("HOME")
+	defer func() { os.Setenv("HOME", origHome) }()
+
+	// HOMEをテスト用ディレクトリに設定
+	os.Setenv("HOME", tmpDir)
+
+	tests := []struct {
+		name         string
+		setupEnv     func()
+		cleanupEnv   func()
+		wantContains []string
+	}{
+		{
+			name: "デフォルト設定（環境変数なし）",
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			cleanupEnv: func() {},
+			wantContains: []string{
+				".config/osoba/osoba.yml",
+				".config/osoba/osoba.yaml",
+				".osoba.yml",
+				".osoba.yaml",
+			},
+		},
+		{
+			name: "XDG_CONFIG_HOMEが設定されている場合",
+			setupEnv: func() {
+				os.Setenv("XDG_CONFIG_HOME", "/custom/config")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			wantContains: []string{
+				"/custom/config/osoba/osoba.yml",
+				"/custom/config/osoba/osoba.yaml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupEnv()
+			defer tt.cleanupEnv()
+
+			paths := getConfigFilePaths()
+
+			for _, want := range tt.wantContains {
+				found := false
+				for _, path := range paths {
+					// パスの最後の部分が一致するかチェック
+					if strings.HasSuffix(filepath.ToSlash(path), filepath.ToSlash(want)) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected paths to contain %s, but it was not found in %v", want, paths)
+				}
+			}
+		})
+	}
+}
+
+func TestFindConfigFile(t *testing.T) {
+	// テスト用の一時ディレクトリを作成
+	tmpDir := t.TempDir()
+
+	// 元の環境変数を保存
+	origHome := os.Getenv("HOME")
+	origXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+
+	// テスト用の環境変数を設定
+	os.Setenv("HOME", tmpDir)
+	defer func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("XDG_CONFIG_HOME", origXDGConfigHome)
+	}()
+
+	tests := []struct {
+		name       string
+		setupFiles func()
+		setupEnv   func()
+		wantFound  bool
+		wantPath   string
+	}{
+		{
+			name:       "設定ファイルが存在しない場合",
+			setupFiles: func() {},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			wantFound: false,
+			wantPath:  "",
+		},
+		{
+			name: "デフォルトパスに設定ファイルが存在する場合",
+			setupFiles: func() {
+				configDir := filepath.Join(tmpDir, ".config", "osoba")
+				os.MkdirAll(configDir, 0755)
+				configFile := filepath.Join(configDir, "osoba.yml")
+				os.WriteFile(configFile, []byte("test"), 0644)
+			},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			wantFound: true,
+			wantPath:  filepath.Join(tmpDir, ".config", "osoba", "osoba.yml"),
+		},
+		{
+			name: "XDG_CONFIG_HOMEのパスに設定ファイルが存在する場合",
+			setupFiles: func() {
+				xdgDir := filepath.Join(tmpDir, "xdg")
+				configDir := filepath.Join(xdgDir, "osoba")
+				os.MkdirAll(configDir, 0755)
+				configFile := filepath.Join(configDir, "osoba.yml")
+				os.WriteFile(configFile, []byte("test"), 0644)
+			},
+			setupEnv: func() {
+				os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+			},
+			wantFound: true,
+			wantPath:  filepath.Join(tmpDir, "xdg", "osoba", "osoba.yml"),
+		},
+		{
+			name: "ホームディレクトリに.osoba.ymlが存在する場合",
+			setupFiles: func() {
+				configFile := filepath.Join(tmpDir, ".osoba.yml")
+				os.WriteFile(configFile, []byte("test"), 0644)
+			},
+			setupEnv: func() {
+				os.Unsetenv("XDG_CONFIG_HOME")
+			},
+			wantFound: true,
+			wantPath:  filepath.Join(tmpDir, ".osoba.yml"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// クリーンアップ
+			os.RemoveAll(filepath.Join(tmpDir, ".config"))
+			os.RemoveAll(filepath.Join(tmpDir, "xdg"))
+			os.Remove(filepath.Join(tmpDir, ".osoba.yml"))
+			os.Remove(filepath.Join(tmpDir, ".osoba.yaml"))
+
+			tt.setupFiles()
+			tt.setupEnv()
+
+			path, found := findConfigFile()
+
+			if found != tt.wantFound {
+				t.Errorf("findConfigFile() found = %v, want %v", found, tt.wantFound)
+			}
+
+			if found && path != tt.wantPath {
+				t.Errorf("findConfigFile() path = %v, want %v", path, tt.wantPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #187
- 対応内容:
  - `osoba start`実行時の設定ファイル存在チェック機能の追加
  - 設定ファイルがない場合の適切なエラーメッセージ表示
  - `osoba init`コマンドの実行を促す案内メッセージの追加
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス
- 関連PR: #187

## 変更内容

### 1. 設定ファイルパス取得の共通関数を追加
- `cmd/utils.go`に`getConfigFilePaths()`と`findConfigFile()`を実装
- 環境変数`XDG_CONFIG_HOME`とデフォルトパスを考慮した優先順位付き探索

### 2. 設定ファイル存在チェック関数を追加
- `cmd/start.go`に`checkConfigFileExists()`を実装
- 日本語でのエラーメッセージと初期化手順の案内を含む

### 3. startコマンドへのチェック機能統合
- `runWatchWithFlags()`の冒頭で設定ファイルチェックを実行
- `startInBackground()`の冒頭でも同様のチェックを実行
- ヘルプ表示時はチェックをスキップ

### 4. テストの追加と既存テストの修正
- 設定ファイル関連の単体テストを追加
- 統合テストでエラーケースと正常ケースを網羅
- 既存テストの環境設定を調整（設定ファイル作成処理を追加）

## 動作確認

設定ファイルがない状態で`osoba start`を実行すると、以下のメッセージが表示されます：

```
エラー: 設定ファイルが見つかりません

以下のいずれかの場所に設定ファイルを配置してください:
  - /home/user/.config/osoba/osoba.yml
  - /home/user/.config/osoba/osoba.yaml
  - /home/user/.osoba.yml
  - /home/user/.osoba.yaml

または、以下のコマンドで初期設定を行ってください:
  osoba init
```

ご確認のほどよろしくお願いいたします。