### PR TITLE
feat: 設定ファイルにauto_merge_lgtmフィールドを追加 (#204)

### DIFF
--- a/cmd/templates/config.yml
+++ b/cmd/templates/config.yml
@@ -2,6 +2,9 @@
 
 github:
   poll_interval: 10s
+  # status:lgtmラベルが付いたPRを自動マージする機能の有効/無効
+  # デフォルト: true（有効）
+  # auto_merge_lgtm: true
 
 tmux:
   session_prefix: "osoba-"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,10 @@ type Config struct {
 
 // GitHubConfig はGitHub関連の設定
 type GitHubConfig struct {
-	PollInterval time.Duration      `mapstructure:"poll_interval"`
-	Labels       LabelConfig        `mapstructure:"labels"`
-	Messages     PhaseMessageConfig `mapstructure:"messages"`
+	PollInterval  time.Duration      `mapstructure:"poll_interval"`
+	Labels        LabelConfig        `mapstructure:"labels"`
+	Messages      PhaseMessageConfig `mapstructure:"messages"`
+	AutoMergeLGTM bool               `mapstructure:"auto_merge_lgtm"` // status:lgtmラベルが付いたPRを自動マージする機能の有効/無効
 }
 
 // LabelConfig は監視対象のラベル設定
@@ -72,7 +73,8 @@ func NewConfig() *Config {
 				Ready:  "status:ready",
 				Review: "status:review-requested",
 			},
-			Messages: NewDefaultPhaseMessageConfig(),
+			Messages:      NewDefaultPhaseMessageConfig(),
+			AutoMergeLGTM: true, // デフォルトで自動マージ機能を有効化
 		},
 		Tmux: TmuxConfig{
 			SessionPrefix: "osoba-",
@@ -110,6 +112,7 @@ func (c *Config) Load(configPath string) error {
 	v.SetDefault("github.messages.plan", "osoba: 計画を作成します")
 	v.SetDefault("github.messages.implement", "osoba: 実装を開始します")
 	v.SetDefault("github.messages.review", "osoba: レビューを開始します")
+	v.SetDefault("github.auto_merge_lgtm", true)
 	v.SetDefault("tmux.session_prefix", "osoba-")
 
 	// ログ設定のデフォルト値

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -282,6 +282,94 @@ func TestConfig_GetLabels(t *testing.T) {
 	}
 }
 
+func TestConfig_AutoMergeLGTM(t *testing.T) {
+	t.Run("正常系: デフォルト値がtrueであることを確認", func(t *testing.T) {
+		cfg := NewConfig()
+		if cfg == nil {
+			t.Fatal("NewConfig() returned nil")
+		}
+
+		// デフォルト値がtrueであることを確認
+		if !cfg.GitHub.AutoMergeLGTM {
+			t.Errorf("default AutoMergeLGTM = %v, want true", cfg.GitHub.AutoMergeLGTM)
+		}
+	})
+
+	t.Run("正常系: 設定ファイルでfalseに設定した場合の読み込み", func(t *testing.T) {
+		// テスト用の設定ファイルを作成
+		content := `
+github:
+  poll_interval: 10s
+  auto_merge_lgtm: false
+`
+		err := os.WriteFile("test_auto_merge_false.yml", []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test config file: %v", err)
+		}
+		defer os.Remove("test_auto_merge_false.yml")
+
+		cfg := NewConfig()
+		err = cfg.Load("test_auto_merge_false.yml")
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+
+		// falseが読み込まれることを確認
+		if cfg.GitHub.AutoMergeLGTM {
+			t.Errorf("AutoMergeLGTM = %v, want false", cfg.GitHub.AutoMergeLGTM)
+		}
+	})
+
+	t.Run("正常系: 設定ファイルでtrueに設定した場合の読み込み", func(t *testing.T) {
+		// テスト用の設定ファイルを作成
+		content := `
+github:
+  poll_interval: 10s
+  auto_merge_lgtm: true
+`
+		err := os.WriteFile("test_auto_merge_true.yml", []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test config file: %v", err)
+		}
+		defer os.Remove("test_auto_merge_true.yml")
+
+		cfg := NewConfig()
+		err = cfg.Load("test_auto_merge_true.yml")
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+
+		// trueが読み込まれることを確認
+		if !cfg.GitHub.AutoMergeLGTM {
+			t.Errorf("AutoMergeLGTM = %v, want true", cfg.GitHub.AutoMergeLGTM)
+		}
+	})
+
+	t.Run("正常系: 設定ファイルに項目がない場合はデフォルト値を使用", func(t *testing.T) {
+		// テスト用の設定ファイルを作成（auto_merge_lgtmフィールドなし）
+		content := `
+github:
+  poll_interval: 10s
+`
+		err := os.WriteFile("test_auto_merge_default.yml", []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test config file: %v", err)
+		}
+		defer os.Remove("test_auto_merge_default.yml")
+
+		cfg := NewConfig()
+		err = cfg.Load("test_auto_merge_default.yml")
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+
+		// デフォルト値（true）が使用されることを確認
+		if !cfg.GitHub.AutoMergeLGTM {
+			t.Errorf("AutoMergeLGTM = %v, want true (default)", cfg.GitHub.AutoMergeLGTM)
+		}
+	})
+}
+
 func TestConfig_LoadOrDefault(t *testing.T) {
 	t.Run("正常系: ファイルが存在しない場合はデフォルト値を使う", func(t *testing.T) {
 		cfg := NewConfig()


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #204
- 対応内容:
  - GitHubConfig構造体にAutoMergeLGTMブール型フィールドを追加
  - デフォルト値をtrueに設定（自動マージ機能をデフォルトで有効化）
  - 設定ファイルテンプレートに機能説明のコメントを追加
  - viperによる設定読み込みでデフォルト値を適切に設定
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス
- 関連PR: このPR

### 変更内容の詳細

1. **GitHubConfig構造体の拡張**
   - `AutoMergeLGTM bool`フィールドを追加
   - mapstructureタグで`auto_merge_lgtm`として設定

2. **デフォルト値の設定**
   - `NewConfig()`関数でデフォルト値を`true`に設定
   - `Load()`関数のviperデフォルト値も`true`に設定

3. **設定ファイルテンプレートの更新**
   - 機能説明のコメントを追加
   - デフォルト値の説明を明記

4. **テストケースの追加**
   - デフォルト値がtrueであることの確認
   - 設定ファイルでfalse/trueに設定した場合の動作確認
   - 設定ファイルに項目がない場合のデフォルト値使用確認

### 後方互換性

既存の設定ファイルとの後方互換性を保証しています。`auto_merge_lgtm`フィールドが設定ファイルに存在しない場合は、デフォルト値（true）が使用されます。

ご確認のほどよろしくお願いいたします。