### PR TITLE
docs: 設定ファイルの説明追加とreview.mdのラベル更新処理追加

### DIFF
--- a/.claude/commands/osoba/review.md
+++ b/.claude/commands/osoba/review.md
@@ -75,6 +75,30 @@ Be sure to run the version *without* `--comments` first to understand the requir
 - [Optional remarks if any]
 ```
 
+### 6. Update Labels
+
+After posting the review result, update the Issue labels based on the verdict:
+
+#### If Approved (LGTM):
+1. Remove `status:reviewing` label:
+   ```bash
+   gh issue edit <issue number> --remove-label "status:reviewing"
+   ```
+2. Add `status:lgtm` label:
+   ```bash
+   gh issue edit <issue number> --add-label "status:lgtm"
+   ```
+
+#### If Requires Changes:
+1. Remove `status:reviewing` label:
+   ```bash
+   gh issue edit <issue number> --remove-label "status:reviewing"
+   ```
+2. Add `status:requires-changes` label:
+   ```bash
+   gh issue edit <issue number> --add-label "status:requires-changes"
+   ```
+
 ## Basic Rules
 
 - Ensure compliance with coding conventions

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ flowchart LR
 # .osoba.yml
 github:
   poll_interval: 10s
+  auto_merge_lgtm: true     # status:lgtmラベル時の自動マージ（デフォルト: true）
+  auto_plan_issue: false    # 新規Issue作成時の自動計画（デフォルト: false）
 
 tmux:
   session_prefix: "osoba-"
@@ -244,6 +246,24 @@ claude:
       args: ["--dangerously-skip-permissions"]
       prompt: "/osoba:review {{issue-number}}"
 ```
+
+#### 設定項目の詳細
+
+##### `auto_merge_lgtm` (boolean)
+- **デフォルト**: `true`
+- **説明**: `status:lgtm`ラベルが付与されたPRを自動的にマージします
+- **動作**: 
+  - `true`に設定すると、レビュー完了後に`status:lgtm`ラベルが付与されたPRを自動マージ
+  - マージ前にCIチェックの成功を確認
+  - マージコンフリクトがある場合は自動マージされません
+
+##### `auto_plan_issue` (boolean)
+- **デフォルト**: `false`
+- **説明**: 新規Issueが作成された際に自動的に計画フェーズを開始します
+- **動作**:
+  - `true`に設定すると、新規Issue作成時に自動的に`status:needs-plan`ラベルを付与
+  - 計画フェーズが自動的に開始され、実行計画がIssueに追記されます
+  - 手動でのラベル付与が不要になり、開発プロセスが完全に自動化されます
 
 ### 環境変数
 

--- a/cmd/templates/commands/review.md
+++ b/cmd/templates/commands/review.md
@@ -75,6 +75,30 @@ Be sure to run the version *without* `--comments` first to understand the requir
 - [Optional remarks if any]
 ```
 
+### 6. Update Labels
+
+After posting the review result, update the Issue labels based on the verdict:
+
+#### If Approved (LGTM):
+1. Remove `status:reviewing` label:
+   ```bash
+   gh issue edit <issue number> --remove-label "status:reviewing"
+   ```
+2. Add `status:lgtm` label:
+   ```bash
+   gh issue edit <issue number> --add-label "status:lgtm"
+   ```
+
+#### If Requires Changes:
+1. Remove `status:reviewing` label:
+   ```bash
+   gh issue edit <issue number> --remove-label "status:reviewing"
+   ```
+2. Add `status:requires-changes` label:
+   ```bash
+   gh issue edit <issue number> --add-label "status:requires-changes"
+   ```
+
 ## Basic Rules
 
 - Ensure compliance with coding conventions


### PR DESCRIPTION
## 概要
設定ファイルの説明をREADME.mdに追加し、レビューコマンドのラベル更新処理を追加しました。

## 変更内容

### 1. README.md
- `auto_merge_lgtm`フィールドの説明を追加（デフォルト値: true）
- `auto_plan_issue`フィールドの説明を追加（デフォルト値: false）
- 各設定項目の動作を詳細に記載

### 2. review.md（コマンドテンプレート）
- レビュー完了後の自動ラベル更新処理を追加
- `status:reviewing`ラベルを削除
- 承認時: `status:lgtm`ラベルを付与
- 修正要求時: `status:requires-changes`ラベルを付与

## 影響範囲
- README.md（ドキュメント）
- .claude/commands/osoba/review.md
- cmd/templates/commands/review.md

## テスト
ドキュメントとコマンドテンプレートの更新のため、動作への影響はありません。