### PR TITLE
fix: status:requires-changes → status:ready ラベル遷移の不具合修正 (#222)

### DIFF
--- a/examples/config/sample-config.yml
+++ b/examples/config/sample-config.yml
@@ -19,6 +19,7 @@ github:
     plan: "status:needs-plan"
     ready: "status:ready"
     review: "status:review-requested"
+    requires_changes: "status:requires-changes"
 
 # tmux設定
 tmux:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,9 +32,10 @@ type GitHubConfig struct {
 
 // LabelConfig は監視対象のラベル設定
 type LabelConfig struct {
-	Plan   string `mapstructure:"plan"`
-	Ready  string `mapstructure:"ready"`
-	Review string `mapstructure:"review"`
+	Plan            string `mapstructure:"plan"`
+	Ready           string `mapstructure:"ready"`
+	Review          string `mapstructure:"review"`
+	RequiresChanges string `mapstructure:"requires_changes"`
 }
 
 // PhaseMessageConfig はフェーズ開始時のコメントメッセージ設定
@@ -70,9 +71,10 @@ func NewConfig() *Config {
 		GitHub: GitHubConfig{
 			PollInterval: 5 * time.Second,
 			Labels: LabelConfig{
-				Plan:   "status:needs-plan",
-				Ready:  "status:ready",
-				Review: "status:review-requested",
+				Plan:            "status:needs-plan",
+				Ready:           "status:ready",
+				Review:          "status:review-requested",
+				RequiresChanges: "status:requires-changes",
 			},
 			Messages:      NewDefaultPhaseMessageConfig(),
 			AutoMergeLGTM: true,  // デフォルトで自動マージ機能を有効化
@@ -111,6 +113,7 @@ func (c *Config) Load(configPath string) error {
 	v.SetDefault("github.labels.plan", "status:needs-plan")
 	v.SetDefault("github.labels.ready", "status:ready")
 	v.SetDefault("github.labels.review", "status:review-requested")
+	v.SetDefault("github.labels.requires_changes", "status:requires-changes")
 	v.SetDefault("github.messages.plan", "osoba: 計画を作成します")
 	v.SetDefault("github.messages.implement", "osoba: 実装を開始します")
 	v.SetDefault("github.messages.review", "osoba: レビューを開始します")
@@ -201,6 +204,9 @@ func (c *Config) Validate() error {
 	if c.GitHub.Labels.Review == "" {
 		c.GitHub.Labels.Review = "status:review-requested"
 	}
+	if c.GitHub.Labels.RequiresChanges == "" {
+		c.GitHub.Labels.RequiresChanges = "status:requires-changes"
+	}
 
 	// tmux設定のバリデーション
 	if c.Tmux.SessionPrefix == "" {
@@ -280,6 +286,7 @@ func (c *Config) GetLabels() []string {
 		c.GitHub.Labels.Plan,
 		c.GitHub.Labels.Ready,
 		c.GitHub.Labels.Review,
+		c.GitHub.Labels.RequiresChanges,
 	}
 }
 
@@ -319,6 +326,22 @@ func GetGitHubToken(cfg *Config) (token string, source string) {
 	}
 
 	return "", ""
+}
+
+// SetDefaults は空フィールドにデフォルト値を設定する
+func (c *Config) SetDefaults() {
+	if c.GitHub.Labels.Plan == "" {
+		c.GitHub.Labels.Plan = "status:needs-plan"
+	}
+	if c.GitHub.Labels.Ready == "" {
+		c.GitHub.Labels.Ready = "status:ready"
+	}
+	if c.GitHub.Labels.Review == "" {
+		c.GitHub.Labels.Review = "status:review-requested"
+	}
+	if c.GitHub.Labels.RequiresChanges == "" {
+		c.GitHub.Labels.RequiresChanges = "status:requires-changes"
+	}
 }
 
 // CreateLogger はログ設定からロガーを作成する

--- a/internal/config/config_requires_changes_test.go
+++ b/internal/config/config_requires_changes_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLabelConfig_RequiresChangesField(t *testing.T) {
+	t.Run("default value for RequiresChanges field", func(t *testing.T) {
+		cfg := NewConfig()
+
+		// デフォルト値が設定されていることを確認
+		assert.Equal(t, "status:requires-changes", cfg.GitHub.Labels.RequiresChanges)
+	})
+
+	t.Run("GetLabels includes requires-changes label", func(t *testing.T) {
+		cfg := &Config{
+			GitHub: GitHubConfig{
+				Labels: LabelConfig{
+					Plan:            "status:needs-plan",
+					Ready:           "status:ready",
+					Review:          "status:review-requested",
+					RequiresChanges: "status:requires-changes",
+				},
+			},
+		}
+
+		labels := cfg.GetLabels()
+
+		// 4つのラベルが含まれることを確認
+		assert.Len(t, labels, 4)
+		assert.Contains(t, labels, "status:needs-plan")
+		assert.Contains(t, labels, "status:ready")
+		assert.Contains(t, labels, "status:review-requested")
+		assert.Contains(t, labels, "status:requires-changes")
+	})
+
+	t.Run("backward compatibility - empty RequiresChanges field", func(t *testing.T) {
+		cfg := &Config{
+			GitHub: GitHubConfig{
+				Labels: LabelConfig{
+					Plan:            "status:needs-plan",
+					Ready:           "status:ready",
+					Review:          "status:review-requested",
+					RequiresChanges: "", // 空の場合
+				},
+			},
+		}
+
+		// SetDefaults が空フィールドにデフォルト値を設定することを確認
+		cfg.SetDefaults()
+		assert.Equal(t, "status:requires-changes", cfg.GitHub.Labels.RequiresChanges)
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -270,16 +270,17 @@ func TestConfig_GetLabels(t *testing.T) {
 	cfg := &Config{
 		GitHub: GitHubConfig{
 			Labels: LabelConfig{
-				Plan:   "status:needs-plan",
-				Ready:  "status:ready",
-				Review: "status:review-requested",
+				Plan:            "status:needs-plan",
+				Ready:           "status:ready",
+				Review:          "status:review-requested",
+				RequiresChanges: "status:requires-changes",
 			},
 		},
 	}
 
 	labels := cfg.GetLabels()
 
-	expected := []string{"status:needs-plan", "status:ready", "status:review-requested"}
+	expected := []string{"status:needs-plan", "status:ready", "status:review-requested", "status:requires-changes"}
 	if len(labels) != len(expected) {
 		t.Fatalf("GetLabels() returned %d labels, want %d", len(labels), len(expected))
 	}

--- a/internal/watcher/action_factory.go
+++ b/internal/watcher/action_factory.go
@@ -15,6 +15,7 @@ type ActionFactory interface {
 	CreatePlanAction() ActionExecutor
 	CreateImplementationAction() ActionExecutor
 	CreateReviewAction() ActionExecutor
+	CreateNoOpAction() ActionExecutor
 }
 
 // DefaultActionFactory はpane管理方式を使用するActionFactory実装
@@ -106,4 +107,9 @@ func (f *DefaultActionFactory) CreateReviewAction() ActionExecutor {
 		f.claudeConfig,
 		f.logger.WithFields("component", "ReviewAction"),
 	)
+}
+
+// CreateNoOpAction は何もしないアクションを作成する（status:requires-changes用）
+func (f *DefaultActionFactory) CreateNoOpAction() ActionExecutor {
+	return NewNoOpAction(f.logger.WithFields("component", "NoOpAction"))
 }

--- a/internal/watcher/action_manager_extended.go
+++ b/internal/watcher/action_manager_extended.go
@@ -57,6 +57,9 @@ func (m *ActionManagerExtended) GetActionForIssue(issue *github.Issue) ActionExe
 	if hasLabel(issue, "status:review-requested") {
 		return m.factory.CreateReviewAction()
 	}
+	if hasLabel(issue, "status:requires-changes") {
+		return m.factory.CreateNoOpAction()
+	}
 
 	return nil
 }

--- a/internal/watcher/action_manager_requires_changes_test.go
+++ b/internal/watcher/action_manager_requires_changes_test.go
@@ -1,0 +1,66 @@
+package watcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douhashi/osoba/internal/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionManagerExtended_RequiresChanges(t *testing.T) {
+	t.Run("returns NoOpAction for status:requires-changes label", func(t *testing.T) {
+		// モックファクトリーを作成
+		mockFactory := new(MockActionFactory)
+		noOpAction := NewNoOpAction(NewMockLogger())
+		mockFactory.On("CreateNoOpAction").Return(noOpAction)
+
+		// ActionManagerを作成
+		manager := NewActionManagerExtended("test-session", mockFactory)
+
+		// status:requires-changesラベルを持つIssueを作成
+		issue := &github.Issue{
+			Number: intPtr(222),
+			Labels: []*github.Label{
+				{Name: stringPtr("status:requires-changes")},
+			},
+		}
+
+		// アクションを取得
+		action := manager.GetActionForIssue(issue)
+
+		// NoOpActionが返されることを確認
+		assert.NotNil(t, action)
+		// NoOpActionの型であることを確認
+		_, ok := action.(*NoOpAction)
+		assert.True(t, ok, "Expected NoOpAction type")
+
+		mockFactory.AssertExpectations(t)
+	})
+
+	t.Run("executes NoOpAction successfully", func(t *testing.T) {
+		// モックファクトリーを作成
+		mockFactory := new(MockActionFactory)
+		noOpAction := NewNoOpAction(NewMockLogger())
+		mockFactory.On("CreateNoOpAction").Return(noOpAction)
+
+		// ActionManagerを作成
+		manager := NewActionManagerExtended("test-session", mockFactory)
+
+		// status:requires-changesラベルを持つIssueを作成
+		issue := &github.Issue{
+			Number: intPtr(222),
+			Labels: []*github.Label{
+				{Name: stringPtr("status:requires-changes")},
+			},
+		}
+
+		// アクションを実行
+		err := manager.ExecuteAction(context.Background(), issue)
+
+		// エラーなく実行されることを確認
+		assert.NoError(t, err)
+
+		mockFactory.AssertExpectations(t)
+	})
+}

--- a/internal/watcher/action_manager_test.go
+++ b/internal/watcher/action_manager_test.go
@@ -53,6 +53,14 @@ func (m *MockActionFactory) CreateReviewAction() ActionExecutor {
 	return args.Get(0).(ActionExecutor)
 }
 
+func (m *MockActionFactory) CreateNoOpAction() ActionExecutor {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(ActionExecutor)
+}
+
 func TestActionManagerExtended_ExecuteAction(t *testing.T) {
 	t.Run("正常系: PlanActionの実行", func(t *testing.T) {
 		// Arrange

--- a/internal/watcher/action_noop.go
+++ b/internal/watcher/action_noop.go
@@ -1,0 +1,50 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+
+	gh "github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/logger"
+)
+
+// NoOpAction は何もしないアクション（status:requires-changes用）
+type NoOpAction struct {
+	logger logger.Logger
+}
+
+// NewNoOpAction は新しいNoOpActionを作成する
+func NewNoOpAction(logger logger.Logger) *NoOpAction {
+	return &NoOpAction{
+		logger: logger,
+	}
+}
+
+// Execute はアクションを実行する（何もしない）
+func (a *NoOpAction) Execute(ctx context.Context, issue *gh.Issue) error {
+	if issue != nil && issue.Number != nil {
+		a.logger.Info("NoOpAction: Skipping action for issue",
+			"issueNumber", *issue.Number,
+			"reason", "No action required for status:requires-changes label")
+	}
+	// 常に成功を返す
+	return nil
+}
+
+// CanExecute はアクションが実行可能かどうかを判定する
+func (a *NoOpAction) CanExecute(issue *gh.Issue) bool {
+	if issue == nil || issue.Number == nil {
+		return false
+	}
+	return true
+}
+
+// GetName はアクション名を返す
+func (a *NoOpAction) GetName() string {
+	return "NoOpAction"
+}
+
+// String はアクションの文字列表現を返す
+func (a *NoOpAction) String() string {
+	return fmt.Sprintf("NoOpAction")
+}

--- a/internal/watcher/action_noop_test.go
+++ b/internal/watcher/action_noop_test.go
@@ -1,0 +1,95 @@
+package watcher
+
+import (
+	"context"
+	"testing"
+
+	gh "github.com/douhashi/osoba/internal/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoOpAction_Execute(t *testing.T) {
+	tests := []struct {
+		name        string
+		issue       *gh.Issue
+		expectError bool
+	}{
+		{
+			name: "successful no-op execution",
+			issue: &gh.Issue{
+				Number: intPtr(222),
+				Title:  stringPtr("Test Issue"),
+				Labels: []*gh.Label{
+					{Name: stringPtr("status:requires-changes")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:        "nil issue",
+			issue:       nil,
+			expectError: false, // NoOp should handle nil gracefully
+		},
+		{
+			name: "issue without number",
+			issue: &gh.Issue{
+				Title: stringPtr("Test Issue"),
+			},
+			expectError: false, // NoOp should handle missing fields gracefully
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := NewNoOpAction(NewMockLogger())
+			err := action.Execute(context.Background(), tt.issue)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNoOpAction_CanExecute(t *testing.T) {
+	tests := []struct {
+		name           string
+		issue          *gh.Issue
+		expectedResult bool
+	}{
+		{
+			name: "can execute with valid issue",
+			issue: &gh.Issue{
+				Number: intPtr(222),
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "cannot execute with nil issue",
+			issue:          nil,
+			expectedResult: false,
+		},
+		{
+			name: "cannot execute without issue number",
+			issue: &gh.Issue{
+				Title: stringPtr("Test Issue"),
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := NewNoOpAction(NewMockLogger())
+			result := action.CanExecute(tt.issue)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestNoOpAction_String(t *testing.T) {
+	action := NewNoOpAction(NewMockLogger())
+	assert.Equal(t, "NoOpAction", action.String())
+}

--- a/internal/watcher/integration_test.go
+++ b/internal/watcher/integration_test.go
@@ -163,6 +163,7 @@ type mockActionFactory struct {
 	planAction           ActionExecutor
 	implementationAction ActionExecutor
 	reviewAction         ActionExecutor
+	noOpAction           ActionExecutor
 }
 
 func (m *mockActionFactory) CreatePlanAction() ActionExecutor {
@@ -175,6 +176,17 @@ func (m *mockActionFactory) CreateImplementationAction() ActionExecutor {
 
 func (m *mockActionFactory) CreateReviewAction() ActionExecutor {
 	return m.reviewAction
+}
+
+func (m *mockActionFactory) CreateNoOpAction() ActionExecutor {
+	if m.noOpAction != nil {
+		return m.noOpAction
+	}
+	// デフォルトでNoOpActionを返す
+	return &mockAction{
+		canExecute: func(issue *github.Issue) bool { return true },
+		execute:    func(ctx context.Context, issue *github.Issue) error { return nil },
+	}
 }
 
 // mockAction はActionExecutorのモック実装


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #222
- 対応内容:
  - LabelConfig構造体にRequiresChangesフィールドを追加し、監視対象ラベルを拡張
  - NoOpActionクラスを実装して、status:requires-changesラベル用の処理を追加
  - ActionManagerを更新し、status:requires-changesラベルの処理を追加
  - GetLabels()メソッドを更新して4つのラベルを返すように変更
  - 既存設定ファイルのサンプルを更新
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス（全パッケージのテストが成功）

## 主な変更点

### 1. 設定構造体の拡張
- `internal/config/config.go`: LabelConfigにRequiresChangesフィールドを追加
- デフォルト値として`status:requires-changes`を設定
- SetDefaults()メソッドで後方互換性を確保

### 2. NoOpActionの実装
- `internal/watcher/action_noop.go`: 何もしないアクションクラスを作成
- status:requires-changesラベル付きIssueは検知されるが、実際のアクションは不要

### 3. ActionManagerの更新
- `internal/watcher/action_manager_extended.go`: status:requires-changesの分岐を追加
- `internal/watcher/action_factory.go`: CreateNoOpAction()メソッドを追加

### 4. テストの追加・更新
- 新規テストファイル: 
  - `internal/config/config_requires_changes_test.go`
  - `internal/watcher/action_manager_requires_changes_test.go`
  - `internal/watcher/action_noop_test.go`
- 既存テストの更新:
  - `internal/config/config_test.go`: GetLabels()が4つのラベルを返すことをテスト
  - `internal/watcher/integration_test.go`: mockActionFactoryにCreateNoOpAction()を追加

ご確認のほどよろしくお願いいたします。