### PR TITLE
feat: ラベル遷移処理の監視・メトリクス機能追加 (#223)

### DIFF
--- a/internal/watcher/label_transition_metrics.go
+++ b/internal/watcher/label_transition_metrics.go
@@ -1,0 +1,275 @@
+package watcher
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// LabelTransitionMetrics はラベル遷移処理のメトリクスを管理する構造体
+type LabelTransitionMetrics struct {
+	mu                    sync.RWMutex
+	TotalTransitions      int64            // 総遷移試行回数
+	SuccessfulTransitions int64            // 成功した遷移数
+	FailedTransitions     int64            // 失敗した遷移数
+	FailureReasons        map[string]int64 // 失敗理由別の回数
+	TransitionTypes       map[string]int64 // 遷移パターン別の回数
+	StartTime             time.Time        // 開始時刻
+	LastTransitionTime    time.Time        // 最後の遷移試行時刻
+}
+
+// TransitionType は遷移パターンとその発生回数を表す構造体
+type TransitionType struct {
+	Type  string // 遷移パターン (例: "status:needs-plan->status:planning")
+	Count int64  // 発生回数
+}
+
+// NewLabelTransitionMetrics は新しいLabelTransitionMetricsを作成する
+func NewLabelTransitionMetrics() *LabelTransitionMetrics {
+	return &LabelTransitionMetrics{
+		TotalTransitions:      0,
+		SuccessfulTransitions: 0,
+		FailedTransitions:     0,
+		FailureReasons:        make(map[string]int64),
+		TransitionTypes:       make(map[string]int64),
+		StartTime:             time.Now(),
+		LastTransitionTime:    time.Time{},
+	}
+}
+
+// RecordSuccess は成功したラベル遷移を記録する
+func (m *LabelTransitionMetrics) RecordSuccess(issueNumber int, transitionType string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.TotalTransitions++
+	m.SuccessfulTransitions++
+	m.TransitionTypes[transitionType]++
+	m.LastTransitionTime = time.Now()
+}
+
+// RecordFailure は失敗したラベル遷移を記録する
+func (m *LabelTransitionMetrics) RecordFailure(issueNumber int, transitionType string, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.TotalTransitions++
+	m.FailedTransitions++
+	m.FailureReasons[reason]++
+	m.TransitionTypes[transitionType]++
+	m.LastTransitionTime = time.Now()
+}
+
+// GetSuccessRate は成功率を百分率で返す
+func (m *LabelTransitionMetrics) GetSuccessRate() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.TotalTransitions == 0 {
+		return 0.0
+	}
+
+	return float64(m.SuccessfulTransitions) / float64(m.TotalTransitions) * 100.0
+}
+
+// GetSuccessRateFormatted はフォーマットされた成功率文字列を返す
+func (m *LabelTransitionMetrics) GetSuccessRateFormatted() string {
+	return fmt.Sprintf("%.2f%%", m.GetSuccessRate())
+}
+
+// GetTopFailureReasons は上位N個の失敗理由を取得する
+func (m *LabelTransitionMetrics) GetTopFailureReasons(limit int) []FailureReason {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.FailureReasons) == 0 {
+		return []FailureReason{}
+	}
+
+	// 失敗理由をスライスに変換
+	reasons := make([]FailureReason, 0, len(m.FailureReasons))
+	for reason, count := range m.FailureReasons {
+		reasons = append(reasons, FailureReason{
+			Reason: reason,
+			Count:  count,
+		})
+	}
+
+	// 発生回数でソート（降順）
+	sort.Slice(reasons, func(i, j int) bool {
+		return reasons[i].Count > reasons[j].Count
+	})
+
+	// 指定された上限まで返す
+	if limit < len(reasons) {
+		return reasons[:limit]
+	}
+
+	return reasons
+}
+
+// GetMostFrequentTransitions は上位N個の頻出遷移パターンを取得する
+func (m *LabelTransitionMetrics) GetMostFrequentTransitions(limit int) []TransitionType {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.TransitionTypes) == 0 {
+		return []TransitionType{}
+	}
+
+	// 遷移パターンをスライスに変換
+	transitions := make([]TransitionType, 0, len(m.TransitionTypes))
+	for transType, count := range m.TransitionTypes {
+		transitions = append(transitions, TransitionType{
+			Type:  transType,
+			Count: count,
+		})
+	}
+
+	// 発生回数でソート（降順）
+	sort.Slice(transitions, func(i, j int) bool {
+		return transitions[i].Count > transitions[j].Count
+	})
+
+	// 指定された上限まで返す
+	if limit < len(transitions) {
+		return transitions[:limit]
+	}
+
+	return transitions
+}
+
+// Reset はメトリクスをリセットする
+func (m *LabelTransitionMetrics) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.TotalTransitions = 0
+	m.SuccessfulTransitions = 0
+	m.FailedTransitions = 0
+	m.FailureReasons = make(map[string]int64)
+	m.TransitionTypes = make(map[string]int64)
+	m.StartTime = time.Now()
+	m.LastTransitionTime = time.Time{}
+}
+
+// GetUptimeDuration は稼働時間を返す
+func (m *LabelTransitionMetrics) GetUptimeDuration() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return time.Since(m.StartTime)
+}
+
+// GetSnapshot はメトリクスのスナップショットを返す（読み取り専用）
+func (m *LabelTransitionMetrics) GetSnapshot() LabelTransitionMetricsSnapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// FailureReasonsのコピーを作成
+	failureReasons := make(map[string]int64)
+	for k, v := range m.FailureReasons {
+		failureReasons[k] = v
+	}
+
+	// TransitionTypesのコピーを作成
+	transitionTypes := make(map[string]int64)
+	for k, v := range m.TransitionTypes {
+		transitionTypes[k] = v
+	}
+
+	return LabelTransitionMetricsSnapshot{
+		TotalTransitions:      m.TotalTransitions,
+		SuccessfulTransitions: m.SuccessfulTransitions,
+		FailedTransitions:     m.FailedTransitions,
+		FailureReasons:        failureReasons,
+		TransitionTypes:       transitionTypes,
+		StartTime:             m.StartTime,
+		LastTransitionTime:    m.LastTransitionTime,
+		SuccessRate:           m.getSuccessRateUnsafe(),
+		UptimeDuration:        time.Since(m.StartTime),
+	}
+}
+
+// getSuccessRateUnsafe は内部用の成功率計算（ロックなし）
+func (m *LabelTransitionMetrics) getSuccessRateUnsafe() float64 {
+	if m.TotalTransitions == 0 {
+		return 0.0
+	}
+	return float64(m.SuccessfulTransitions) / float64(m.TotalTransitions) * 100.0
+}
+
+// LabelTransitionMetricsSnapshot はメトリクスの読み取り専用スナップショット
+type LabelTransitionMetricsSnapshot struct {
+	TotalTransitions      int64
+	SuccessfulTransitions int64
+	FailedTransitions     int64
+	FailureReasons        map[string]int64
+	TransitionTypes       map[string]int64
+	StartTime             time.Time
+	LastTransitionTime    time.Time
+	SuccessRate           float64
+	UptimeDuration        time.Duration
+}
+
+// GetSuccessRateFormatted はフォーマットされた成功率文字列を返す
+func (s LabelTransitionMetricsSnapshot) GetSuccessRateFormatted() string {
+	return fmt.Sprintf("%.2f%%", s.SuccessRate)
+}
+
+// GetTopFailureReasons は上位N個の失敗理由を取得する
+func (s LabelTransitionMetricsSnapshot) GetTopFailureReasons(limit int) []FailureReason {
+	if len(s.FailureReasons) == 0 {
+		return []FailureReason{}
+	}
+
+	// 失敗理由をスライスに変換
+	reasons := make([]FailureReason, 0, len(s.FailureReasons))
+	for reason, count := range s.FailureReasons {
+		reasons = append(reasons, FailureReason{
+			Reason: reason,
+			Count:  count,
+		})
+	}
+
+	// 発生回数でソート（降順）
+	sort.Slice(reasons, func(i, j int) bool {
+		return reasons[i].Count > reasons[j].Count
+	})
+
+	// 指定された上限まで返す
+	if limit < len(reasons) {
+		return reasons[:limit]
+	}
+
+	return reasons
+}
+
+// GetMostFrequentTransitions は上位N個の頻出遷移パターンを取得する
+func (s LabelTransitionMetricsSnapshot) GetMostFrequentTransitions(limit int) []TransitionType {
+	if len(s.TransitionTypes) == 0 {
+		return []TransitionType{}
+	}
+
+	// 遷移パターンをスライスに変換
+	transitions := make([]TransitionType, 0, len(s.TransitionTypes))
+	for transType, count := range s.TransitionTypes {
+		transitions = append(transitions, TransitionType{
+			Type:  transType,
+			Count: count,
+		})
+	}
+
+	// 発生回数でソート（降順）
+	sort.Slice(transitions, func(i, j int) bool {
+		return transitions[i].Count > transitions[j].Count
+	})
+
+	// 指定された上限まで返す
+	if limit < len(transitions) {
+		return transitions[:limit]
+	}
+
+	return transitions
+}

--- a/internal/watcher/label_transition_metrics_test.go
+++ b/internal/watcher/label_transition_metrics_test.go
@@ -1,0 +1,347 @@
+package watcher
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLabelTransitionMetrics(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	assert.NotNil(t, metrics)
+	assert.Equal(t, int64(0), metrics.TotalTransitions)
+	assert.Equal(t, int64(0), metrics.SuccessfulTransitions)
+	assert.Equal(t, int64(0), metrics.FailedTransitions)
+	assert.Empty(t, metrics.FailureReasons)
+	assert.Empty(t, metrics.TransitionTypes)
+	assert.True(t, metrics.StartTime.After(time.Time{}))
+}
+
+func TestLabelTransitionMetrics_RecordSuccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		issueNum   int
+		transition string
+	}{
+		{
+			name:       "needs-plan to planning",
+			issueNum:   123,
+			transition: "status:needs-plan->status:planning",
+		},
+		{
+			name:       "ready to implementing",
+			issueNum:   456,
+			transition: "status:ready->status:implementing",
+		},
+		{
+			name:       "review-requested to reviewing",
+			issueNum:   789,
+			transition: "status:review-requested->status:reviewing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewLabelTransitionMetrics()
+
+			metrics.RecordSuccess(tt.issueNum, tt.transition)
+
+			assert.Equal(t, int64(1), metrics.TotalTransitions)
+			assert.Equal(t, int64(1), metrics.SuccessfulTransitions)
+			assert.Equal(t, int64(0), metrics.FailedTransitions)
+			assert.Equal(t, int64(1), metrics.TransitionTypes[tt.transition])
+			assert.True(t, metrics.LastTransitionTime.After(metrics.StartTime))
+		})
+	}
+}
+
+func TestLabelTransitionMetrics_RecordFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		issueNum   int
+		transition string
+		reason     string
+	}{
+		{
+			name:       "API error",
+			issueNum:   123,
+			transition: "status:needs-plan->status:planning",
+			reason:     "api_error",
+		},
+		{
+			name:       "permission denied",
+			issueNum:   456,
+			transition: "status:ready->status:implementing",
+			reason:     "permission_denied",
+		},
+		{
+			name:       "timeout",
+			issueNum:   789,
+			transition: "status:review-requested->status:reviewing",
+			reason:     "timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewLabelTransitionMetrics()
+
+			metrics.RecordFailure(tt.issueNum, tt.transition, tt.reason)
+
+			assert.Equal(t, int64(1), metrics.TotalTransitions)
+			assert.Equal(t, int64(0), metrics.SuccessfulTransitions)
+			assert.Equal(t, int64(1), metrics.FailedTransitions)
+			assert.Equal(t, int64(1), metrics.FailureReasons[tt.reason])
+			assert.Equal(t, int64(1), metrics.TransitionTypes[tt.transition])
+			assert.True(t, metrics.LastTransitionTime.After(metrics.StartTime))
+		})
+	}
+}
+
+func TestLabelTransitionMetrics_RecordMultipleTransitions(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	// 複数の成功と失敗を記録
+	metrics.RecordSuccess(123, "status:needs-plan->status:planning")
+	metrics.RecordSuccess(124, "status:needs-plan->status:planning")
+	metrics.RecordFailure(125, "status:ready->status:implementing", "api_error")
+	metrics.RecordFailure(126, "status:ready->status:implementing", "api_error")
+	metrics.RecordFailure(127, "status:review-requested->status:reviewing", "timeout")
+
+	assert.Equal(t, int64(5), metrics.TotalTransitions)
+	assert.Equal(t, int64(2), metrics.SuccessfulTransitions)
+	assert.Equal(t, int64(3), metrics.FailedTransitions)
+	assert.Equal(t, int64(2), metrics.FailureReasons["api_error"])
+	assert.Equal(t, int64(1), metrics.FailureReasons["timeout"])
+	assert.Equal(t, int64(2), metrics.TransitionTypes["status:needs-plan->status:planning"])
+	assert.Equal(t, int64(2), metrics.TransitionTypes["status:ready->status:implementing"])
+	assert.Equal(t, int64(1), metrics.TransitionTypes["status:review-requested->status:reviewing"])
+}
+
+func TestLabelTransitionMetrics_GetSuccessRate(t *testing.T) {
+	tests := []struct {
+		name                  string
+		successfulTransitions int64
+		totalTransitions      int64
+		expectedRate          float64
+		expectedFormatted     string
+	}{
+		{
+			name:                  "100% success rate",
+			successfulTransitions: 10,
+			totalTransitions:      10,
+			expectedRate:          100.0,
+			expectedFormatted:     "100.00%",
+		},
+		{
+			name:                  "75% success rate",
+			successfulTransitions: 3,
+			totalTransitions:      4,
+			expectedRate:          75.0,
+			expectedFormatted:     "75.00%",
+		},
+		{
+			name:                  "0% success rate",
+			successfulTransitions: 0,
+			totalTransitions:      5,
+			expectedRate:          0.0,
+			expectedFormatted:     "0.00%",
+		},
+		{
+			name:                  "no transitions",
+			successfulTransitions: 0,
+			totalTransitions:      0,
+			expectedRate:          0.0,
+			expectedFormatted:     "0.00%",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := &LabelTransitionMetrics{
+				TotalTransitions:      tt.totalTransitions,
+				SuccessfulTransitions: tt.successfulTransitions,
+				FailureReasons:        make(map[string]int64),
+				TransitionTypes:       make(map[string]int64),
+			}
+
+			assert.Equal(t, tt.expectedRate, metrics.GetSuccessRate())
+			assert.Equal(t, tt.expectedFormatted, metrics.GetSuccessRateFormatted())
+		})
+	}
+}
+
+func TestLabelTransitionMetrics_GetTopFailureReasons(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	// 失敗理由を記録
+	metrics.FailureReasons["api_error"] = 10
+	metrics.FailureReasons["timeout"] = 5
+	metrics.FailureReasons["permission_denied"] = 8
+	metrics.FailureReasons["not_found"] = 2
+
+	// 上位3つの失敗理由を取得
+	topReasons := metrics.GetTopFailureReasons(3)
+
+	assert.Equal(t, 3, len(topReasons))
+	assert.Equal(t, "api_error", topReasons[0].Reason)
+	assert.Equal(t, int64(10), topReasons[0].Count)
+	assert.Equal(t, "permission_denied", topReasons[1].Reason)
+	assert.Equal(t, int64(8), topReasons[1].Count)
+	assert.Equal(t, "timeout", topReasons[2].Reason)
+	assert.Equal(t, int64(5), topReasons[2].Count)
+
+	// 上限より多く指定した場合
+	allReasons := metrics.GetTopFailureReasons(10)
+	assert.Equal(t, 4, len(allReasons))
+
+	// 失敗理由がない場合
+	emptyMetrics := NewLabelTransitionMetrics()
+	emptyReasons := emptyMetrics.GetTopFailureReasons(5)
+	assert.Equal(t, 0, len(emptyReasons))
+}
+
+func TestLabelTransitionMetrics_GetMostFrequentTransitions(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	// 遷移パターンを記録
+	metrics.TransitionTypes["status:needs-plan->status:planning"] = 15
+	metrics.TransitionTypes["status:ready->status:implementing"] = 10
+	metrics.TransitionTypes["status:review-requested->status:reviewing"] = 20
+	metrics.TransitionTypes["status:requires-changes->status:ready"] = 5
+
+	// 上位3つの遷移パターンを取得
+	topTransitions := metrics.GetMostFrequentTransitions(3)
+
+	assert.Equal(t, 3, len(topTransitions))
+	assert.Equal(t, "status:review-requested->status:reviewing", topTransitions[0].Type)
+	assert.Equal(t, int64(20), topTransitions[0].Count)
+	assert.Equal(t, "status:needs-plan->status:planning", topTransitions[1].Type)
+	assert.Equal(t, int64(15), topTransitions[1].Count)
+	assert.Equal(t, "status:ready->status:implementing", topTransitions[2].Type)
+	assert.Equal(t, int64(10), topTransitions[2].Count)
+}
+
+func TestLabelTransitionMetrics_Reset(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	// データを追加
+	metrics.RecordSuccess(123, "status:needs-plan->status:planning")
+	metrics.RecordFailure(456, "status:ready->status:implementing", "api_error")
+
+	// 初期データが設定されていることを確認
+	assert.Equal(t, int64(2), metrics.TotalTransitions)
+	assert.NotEmpty(t, metrics.FailureReasons)
+	assert.NotEmpty(t, metrics.TransitionTypes)
+
+	// リセット
+	metrics.Reset()
+
+	// リセット後の確認
+	assert.Equal(t, int64(0), metrics.TotalTransitions)
+	assert.Equal(t, int64(0), metrics.SuccessfulTransitions)
+	assert.Equal(t, int64(0), metrics.FailedTransitions)
+	assert.Empty(t, metrics.FailureReasons)
+	assert.Empty(t, metrics.TransitionTypes)
+}
+
+func TestLabelTransitionMetrics_GetSnapshot(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	// データを追加
+	metrics.RecordSuccess(123, "status:needs-plan->status:planning")
+	metrics.RecordFailure(456, "status:ready->status:implementing", "api_error")
+
+	// スナップショットを取得
+	snapshot := metrics.GetSnapshot()
+
+	// スナップショットの内容を確認
+	assert.Equal(t, int64(2), snapshot.TotalTransitions)
+	assert.Equal(t, int64(1), snapshot.SuccessfulTransitions)
+	assert.Equal(t, int64(1), snapshot.FailedTransitions)
+	assert.Equal(t, int64(1), snapshot.FailureReasons["api_error"])
+	assert.Equal(t, int64(1), snapshot.TransitionTypes["status:needs-plan->status:planning"])
+	assert.Equal(t, int64(1), snapshot.TransitionTypes["status:ready->status:implementing"])
+	assert.Equal(t, 50.0, snapshot.SuccessRate)
+
+	// スナップショット取得後に元のメトリクスを変更
+	metrics.RecordSuccess(789, "status:review-requested->status:reviewing")
+
+	// スナップショットは変更されないことを確認
+	assert.Equal(t, int64(2), snapshot.TotalTransitions)
+	assert.Equal(t, int64(3), metrics.TotalTransitions)
+}
+
+func TestLabelTransitionMetrics_ConcurrentAccess(t *testing.T) {
+	metrics := NewLabelTransitionMetrics()
+
+	// 並行アクセスでのdata race検証
+	var wg sync.WaitGroup
+	concurrency := 100
+
+	// 並行書き込み
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				metrics.RecordSuccess(i, "status:needs-plan->status:planning")
+			} else {
+				metrics.RecordFailure(i, "status:ready->status:implementing", "api_error")
+			}
+		}(i)
+	}
+
+	// 並行読み込み
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = metrics.GetSuccessRate()
+			_ = metrics.GetSnapshot()
+			_ = metrics.GetTopFailureReasons(5)
+		}()
+	}
+
+	wg.Wait()
+
+	// 合計トランザクション数が正しいことを確認
+	assert.Equal(t, int64(concurrency), metrics.TotalTransitions)
+	assert.Equal(t, int64(concurrency/2), metrics.SuccessfulTransitions)
+	assert.Equal(t, int64(concurrency/2), metrics.FailedTransitions)
+}
+
+func TestLabelTransitionMetricsSnapshot_Methods(t *testing.T) {
+	snapshot := LabelTransitionMetricsSnapshot{
+		TotalTransitions:      10,
+		SuccessfulTransitions: 7,
+		FailedTransitions:     3,
+		SuccessRate:           70.0,
+		FailureReasons: map[string]int64{
+			"api_error":         2,
+			"permission_denied": 1,
+		},
+		TransitionTypes: map[string]int64{
+			"status:needs-plan->status:planning":        5,
+			"status:ready->status:implementing":         3,
+			"status:review-requested->status:reviewing": 2,
+		},
+	}
+
+	// GetSuccessRateFormatted
+	assert.Equal(t, "70.00%", snapshot.GetSuccessRateFormatted())
+
+	// GetTopFailureReasons
+	topReasons := snapshot.GetTopFailureReasons(1)
+	assert.Equal(t, 1, len(topReasons))
+	assert.Equal(t, "api_error", topReasons[0].Reason)
+
+	// GetMostFrequentTransitions
+	topTransitions := snapshot.GetMostFrequentTransitions(2)
+	assert.Equal(t, 2, len(topTransitions))
+	assert.Equal(t, "status:needs-plan->status:planning", topTransitions[0].Type)
+	assert.Equal(t, int64(5), topTransitions[0].Count)
+}


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #223
- 対応内容:
  - ラベル遷移の成功/失敗を記録するLabelTransitionMetrics構造体を実装
  - executeLabelTransitionメソッド内でメトリクス記録処理を追加
  - ヘルスチェック機能を拡張してラベル遷移メトリクスを含める
  - 遷移パターン別・失敗理由別の詳細な集計機能を実装
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス

## 主な変更点

### 新規ファイル
- `internal/watcher/label_transition_metrics.go` - メトリクス管理構造体
- `internal/watcher/label_transition_metrics_test.go` - 包括的なテストケース

### 既存ファイルの変更
- `internal/watcher/watcher.go`:
  - IssueWatcher構造体にlabelTransitionMetricsフィールドを追加
  - executeLabelTransitionメソッドでメトリクス記録を実装
  - CheckHealthメソッドでラベル遷移メトリクスを含めるよう拡張
  - GetLabelTransitionMetricsメソッドを追加

## テスト内容

- メトリクスの基本的な記録・集計機能
- 並行アクセス時のスレッドセーフ性
- 成功率計算とフォーマット
- 失敗理由の上位N件取得
- 遷移パターンの頻出順取得
- スナップショット機能
- ヘルスチェックとの統合

## 確認事項

- [x] すべてのテストがパス
- [x] go fmtによるフォーマット完了
- [x] メトリクス記録が既存のラベル遷移処理に影響しない
- [x] スレッドセーフな実装

ご確認のほどよろしくお願いいたします。