### PR TITLE
fix: auto merge機能の実環境動作検証と問題修正 (#227)

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,6 +17,8 @@ import (
 type GHClient struct {
 	logger       logger.Logger
 	labelManager LabelManagerInterface
+	owner        string
+	repo         string
 }
 
 // NewClient は新しいGitHub APIクライアントを作成する（ghコマンドベース）
@@ -24,9 +26,14 @@ func NewClient(token string) (*GHClient, error) {
 	// ghコマンドは環境変数やconfigでトークンを管理するため、ここでは不要
 	labelManager := NewGHLabelManager(nil, 3, 1*time.Second)
 
-	return &GHClient{
+	client := &GHClient{
 		labelManager: labelManager,
-	}, nil
+	}
+
+	// リポジトリ情報を取得
+	client.initRepoInfo(context.Background())
+
+	return client, nil
 }
 
 // NewClientWithLogger はログ機能付きの新しいGitHub APIクライアントを作成する（ghコマンドベース）
@@ -37,10 +44,15 @@ func NewClientWithLogger(token string, logger logger.Logger) (*GHClient, error) 
 
 	labelManager := NewGHLabelManager(logger, 3, 1*time.Second)
 
-	return &GHClient{
+	client := &GHClient{
 		logger:       logger,
 		labelManager: labelManager,
-	}, nil
+	}
+
+	// リポジトリ情報を取得
+	client.initRepoInfo(context.Background())
+
+	return client, nil
 }
 
 // NewClientWithLabelManager はテスト用のクライアントコンストラクタ

--- a/internal/github/pull_request_fallback.go
+++ b/internal/github/pull_request_fallback.go
@@ -1,0 +1,78 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// SearchPullRequestByBranch はブランチ名でPRを検索する
+func (c *GHClient) SearchPullRequestByBranch(ctx context.Context, branchName string) (*PullRequest, error) {
+	// gh pr list --head <branch-name> --json number,title,state,mergeable,isDraft,headRefName,statusCheckRollup
+	args := []string{
+		"pr", "list",
+		"--head", branchName,
+		"--json", "number,title,state,mergeable,isDraft,headRefName,statusCheckRollup",
+		"--state", "open",
+	}
+
+	if c.logger != nil {
+		c.logger.Debug("Searching PR by branch name",
+			"branch_name", branchName,
+		)
+	}
+
+	output, err := c.executeGHCommand(ctx, args...)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Debug("Failed to search PR by branch",
+				"branch_name", branchName,
+				"error", err,
+			)
+		}
+		return nil, fmt.Errorf("failed to search pull request by branch %s: %w", branchName, err)
+	}
+
+	if c.logger != nil {
+		c.logger.Debug("Raw branch search output",
+			"branch_name", branchName,
+			"output", string(output),
+		)
+	}
+
+	var prs []pullRequestWithStatus
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return nil, fmt.Errorf("failed to parse pull request response: %w", err)
+	}
+
+	if len(prs) == 0 {
+		if c.logger != nil {
+			c.logger.Debug("No PR found for branch",
+				"branch_name", branchName,
+			)
+		}
+		return nil, nil // PRが存在しない
+	}
+
+	// 最初のPRを返す
+	pr := &PullRequest{
+		Number:       prs[0].Number,
+		Title:        prs[0].Title,
+		State:        prs[0].State,
+		Mergeable:    prs[0].Mergeable,
+		IsDraft:      prs[0].IsDraft,
+		HeadRefName:  prs[0].HeadRefName,
+		ChecksStatus: prs[0].StatusCheckRollup.State,
+	}
+
+	if c.logger != nil {
+		c.logger.Debug("Found PR by branch name",
+			"branch_name", branchName,
+			"pr_number", pr.Number,
+			"state", pr.State,
+			"mergeable", pr.Mergeable,
+		)
+	}
+
+	return pr, nil
+}

--- a/internal/github/pull_request_graphql.go
+++ b/internal/github/pull_request_graphql.go
@@ -1,0 +1,136 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// GetPullRequestForIssueViaGraphQL はGraphQL APIを使用してIssueに関連するPRを取得
+func (c *GHClient) GetPullRequestForIssueViaGraphQL(ctx context.Context, issueNumber int) (*PullRequest, error) {
+	query := fmt.Sprintf(`
+	{
+		repository(owner: "%s", name: "%s") {
+			issue(number: %d) {
+				timelineItems(first: 50, itemTypes: [CROSS_REFERENCED_EVENT]) {
+					nodes {
+						__typename
+						... on CrossReferencedEvent {
+							source {
+								__typename
+								... on PullRequest {
+									number
+									title
+									state
+									isDraft
+									mergeable
+									headRefName
+									statusCheckRollup {
+										state
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`, c.owner, c.repo, issueNumber)
+
+	args := []string{
+		"api", "graphql",
+		"-f", fmt.Sprintf("query=%s", query),
+	}
+
+	if c.logger != nil {
+		c.logger.Debug("Executing GraphQL query for PR search",
+			"issue_number", issueNumber,
+		)
+	}
+
+	output, err := c.executeGHCommand(ctx, args...)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Error("GraphQL query failed",
+				"issue_number", issueNumber,
+				"error", err,
+			)
+		}
+		return nil, fmt.Errorf("GraphQL query failed: %w", err)
+	}
+
+	// レスポンスをパース
+	var response struct {
+		Data struct {
+			Repository struct {
+				Issue struct {
+					TimelineItems struct {
+						Nodes []struct {
+							TypeName string `json:"__typename"`
+							Source   struct {
+								TypeName          string `json:"__typename"`
+								Number            int    `json:"number"`
+								Title             string `json:"title"`
+								State             string `json:"state"`
+								IsDraft           bool   `json:"isDraft"`
+								Mergeable         string `json:"mergeable"`
+								HeadRefName       string `json:"headRefName"`
+								StatusCheckRollup struct {
+									State string `json:"state"`
+								} `json:"statusCheckRollup"`
+							} `json:"source"`
+						} `json:"nodes"`
+					} `json:"timelineItems"`
+				} `json:"issue"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(output, &response); err != nil {
+		if c.logger != nil {
+			c.logger.Error("Failed to parse GraphQL response",
+				"issue_number", issueNumber,
+				"error", err,
+				"raw_output", string(output),
+			)
+		}
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	// CrossReferencedEventからPRを探す
+	for _, node := range response.Data.Repository.Issue.TimelineItems.Nodes {
+		if node.TypeName == "CrossReferencedEvent" && node.Source.TypeName == "PullRequest" {
+			// オープンなPRのみを対象にする
+			if node.Source.State == "OPEN" {
+				pr := &PullRequest{
+					Number:       node.Source.Number,
+					Title:        node.Source.Title,
+					State:        node.Source.State,
+					Mergeable:    node.Source.Mergeable,
+					IsDraft:      node.Source.IsDraft,
+					HeadRefName:  node.Source.HeadRefName,
+					ChecksStatus: node.Source.StatusCheckRollup.State,
+				}
+
+				if c.logger != nil {
+					c.logger.Debug("Found PR via GraphQL",
+						"issue_number", issueNumber,
+						"pr_number", pr.Number,
+						"state", pr.State,
+						"mergeable", pr.Mergeable,
+					)
+				}
+
+				return pr, nil
+			}
+		}
+	}
+
+	if c.logger != nil {
+		c.logger.Debug("No open PR found via GraphQL",
+			"issue_number", issueNumber,
+		)
+	}
+
+	return nil, nil
+}

--- a/internal/github/pull_request_search.go
+++ b/internal/github/pull_request_search.go
@@ -1,0 +1,228 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// SearchPullRequestForIssue はIssue番号に関連するPRを複数の方法で検索する
+func (c *GHClient) SearchPullRequestForIssue(ctx context.Context, issueNumber int) (*PullRequest, error) {
+	if c.logger != nil {
+		c.logger.Debug("Starting comprehensive PR search for issue",
+			"issue_number", issueNumber,
+		)
+	}
+
+	// 方法1: linked検索（従来の方法）
+	pr, err := c.searchByLinkedQuery(ctx, issueNumber)
+	if err == nil && pr != nil {
+		if c.logger != nil {
+			c.logger.Info("Found PR via linked search",
+				"issue_number", issueNumber,
+				"pr_number", pr.Number,
+			)
+		}
+		return pr, nil
+	}
+
+	// 方法2: PR本文でのIssue番号検索
+	pr, err = c.searchByBodyMention(ctx, issueNumber)
+	if err == nil && pr != nil {
+		if c.logger != nil {
+			c.logger.Info("Found PR via body mention search",
+				"issue_number", issueNumber,
+				"pr_number", pr.Number,
+			)
+		}
+		return pr, nil
+	}
+
+	// 方法3: ブランチ名パターンによる検索
+	pr, err = c.searchByBranchPattern(ctx, issueNumber)
+	if err == nil && pr != nil {
+		if c.logger != nil {
+			c.logger.Info("Found PR via branch pattern",
+				"issue_number", issueNumber,
+				"pr_number", pr.Number,
+			)
+		}
+		return pr, nil
+	}
+
+	if c.logger != nil {
+		c.logger.Debug("No PR found for issue after all search methods",
+			"issue_number", issueNumber,
+		)
+	}
+
+	return nil, nil
+}
+
+// searchByLinkedQuery は従来のlinked検索を行う
+func (c *GHClient) searchByLinkedQuery(ctx context.Context, issueNumber int) (*PullRequest, error) {
+	args := []string{
+		"pr", "list",
+		"--search", fmt.Sprintf("linked:%d", issueNumber),
+		"--json", "number,title,state,mergeable,isDraft,headRefName,statusCheckRollup",
+		"--state", "open",
+	}
+
+	output, err := c.executeGHCommand(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []pullRequestWithStatus
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return nil, err
+	}
+
+	if len(prs) > 0 {
+		return convertToPullRequest(&prs[0]), nil
+	}
+
+	return nil, nil
+}
+
+// searchByBodyMention はPR本文にIssue番号が記載されているPRを検索
+func (c *GHClient) searchByBodyMention(ctx context.Context, issueNumber int) (*PullRequest, error) {
+	// すべてのオープンPRを取得
+	args := []string{
+		"pr", "list",
+		"--json", "number,title,state,mergeable,isDraft,headRefName,statusCheckRollup,body",
+		"--state", "open",
+		"--limit", "100",
+	}
+
+	output, err := c.executeGHCommand(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []struct {
+		pullRequestWithStatus
+		Body string `json:"body"`
+	}
+
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return nil, err
+	}
+
+	// Issue番号の記載パターン
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(fmt.Sprintf(`(?i)fixes\s+#%d\b`, issueNumber)),
+		regexp.MustCompile(fmt.Sprintf(`(?i)closes\s+#%d\b`, issueNumber)),
+		regexp.MustCompile(fmt.Sprintf(`(?i)resolves\s+#%d\b`, issueNumber)),
+		regexp.MustCompile(fmt.Sprintf(`#%d\b`, issueNumber)),
+	}
+
+	for _, pr := range prs {
+		for _, pattern := range patterns {
+			if pattern.MatchString(pr.Body) {
+				if c.logger != nil {
+					c.logger.Debug("Found PR with issue mention in body",
+						"issue_number", issueNumber,
+						"pr_number", pr.Number,
+						"pattern", pattern.String(),
+					)
+				}
+				return convertToPullRequest(&pr.pullRequestWithStatus), nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// searchByBranchPattern はブランチ名パターンでPRを検索
+func (c *GHClient) searchByBranchPattern(ctx context.Context, issueNumber int) (*PullRequest, error) {
+	branchPatterns := []string{
+		fmt.Sprintf("issue-%d", issueNumber),
+		fmt.Sprintf("fix-%d", issueNumber),
+		fmt.Sprintf("feature-%d", issueNumber),
+		fmt.Sprintf("issue/%d", issueNumber),
+		fmt.Sprintf("fix/%d", issueNumber),
+		fmt.Sprintf("feature/%d", issueNumber),
+		fmt.Sprintf("issue/%03d", issueNumber),
+		fmt.Sprintf("fix/%03d", issueNumber),
+	}
+
+	for _, pattern := range branchPatterns {
+		pr, err := c.SearchPullRequestByBranch(ctx, pattern)
+		if err != nil {
+			continue
+		}
+		if pr != nil {
+			return pr, nil
+		}
+	}
+
+	// 正規表現パターンで幅広く検索
+	args := []string{
+		"pr", "list",
+		"--json", "number,title,state,mergeable,isDraft,headRefName,statusCheckRollup",
+		"--state", "open",
+		"--limit", "100",
+	}
+
+	output, err := c.executeGHCommand(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []pullRequestWithStatus
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return nil, err
+	}
+
+	// Issue番号を含むブランチ名のパターン
+	branchRegex := regexp.MustCompile(fmt.Sprintf(`\b%d\b`, issueNumber))
+
+	for _, pr := range prs {
+		if branchRegex.MatchString(pr.HeadRefName) {
+			if c.logger != nil {
+				c.logger.Debug("Found PR with issue number in branch name",
+					"issue_number", issueNumber,
+					"pr_number", pr.Number,
+					"branch", pr.HeadRefName,
+				)
+			}
+			return convertToPullRequest(&pr), nil
+		}
+	}
+
+	return nil, nil
+}
+
+// convertToPullRequest はpullRequestWithStatusをPullRequestに変換
+func convertToPullRequest(pr *pullRequestWithStatus) *PullRequest {
+	return &PullRequest{
+		Number:       pr.Number,
+		Title:        pr.Title,
+		State:        pr.State,
+		Mergeable:    pr.Mergeable,
+		IsDraft:      pr.IsDraft,
+		HeadRefName:  pr.HeadRefName,
+		ChecksStatus: pr.StatusCheckRollup.State,
+	}
+}
+
+// GetPullRequestForIssueWithFallback は複数の検索方法を試すラッパー関数
+func (c *GHClient) GetPullRequestForIssueWithFallback(ctx context.Context, issueNumber int) (*PullRequest, error) {
+	// まず従来のGetPullRequestForIssueを試す
+	pr, err := c.GetPullRequestForIssue(ctx, issueNumber)
+	if err == nil && pr != nil {
+		return pr, nil
+	}
+
+	// 失敗したら包括的な検索を実施
+	if c.logger != nil {
+		c.logger.Debug("Falling back to comprehensive search",
+			"issue_number", issueNumber,
+		)
+	}
+
+	return c.SearchPullRequestForIssue(ctx, issueNumber)
+}

--- a/internal/github/repo_info.go
+++ b/internal/github/repo_info.go
@@ -1,0 +1,73 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// initRepoInfo はリポジトリ情報を初期化する
+func (c *GHClient) initRepoInfo(ctx context.Context) error {
+	// gh repo view --json owner,name でリポジトリ情報を取得
+	output, err := c.executeGHCommand(ctx, "repo", "view", "--json", "owner,name")
+	if err != nil {
+		// エラーが発生してもフォールバック値を使用
+		c.owner = "douhashi"
+		c.repo = "osoba"
+		return nil
+	}
+
+	var repoInfo struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	}
+
+	if err := json.Unmarshal(output, &repoInfo); err != nil {
+		// パースエラーの場合もフォールバック
+		c.owner = "douhashi"
+		c.repo = "osoba"
+		return nil
+	}
+
+	c.owner = repoInfo.Owner.Login
+	c.repo = repoInfo.Name
+
+	if c.logger != nil {
+		c.logger.Debug("Repository info initialized",
+			"owner", c.owner,
+			"repo", c.repo,
+		)
+	}
+
+	return nil
+}
+
+// GetRepoInfo はowner/repo情報を返す
+func (c *GHClient) GetRepoInfo() (string, string) {
+	// 未初期化の場合は初期化を試みる
+	if c.owner == "" || c.repo == "" {
+		c.initRepoInfo(context.Background())
+	}
+
+	// それでも空の場合はデフォルト値
+	if c.owner == "" {
+		c.owner = "douhashi"
+	}
+	if c.repo == "" {
+		c.repo = "osoba"
+	}
+
+	return c.owner, c.repo
+}
+
+// parseRepoFromURL はGitHub URLからowner/repoを抽出する
+func parseRepoFromURL(url string) (string, string) {
+	// https://github.com/owner/repo 形式のURLからowner/repoを抽出
+	parts := strings.Split(url, "/")
+	if len(parts) >= 5 && parts[2] == "github.com" {
+		return parts[3], parts[4]
+	}
+	return "", ""
+}


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #227
- 対応内容:
  - `gh pr list --search "linked:XXX"`が動作しない問題の根本原因を特定
  - GraphQL APIを使用した確実なPR検索機能の実装
  - 複数の検索方法によるフォールバック機構の追加
  - デバッグログの強化とAPIレスポンス記録機能の追加
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス（全パッケージ）

## 問題の詳細

### 根本原因
`gh pr list --search "linked:XXX"`コマンドが期待通りに動作しない。過去のPR（例: #226）も「fixes #223」と正しく記載されているにも関わらず、`linked:`検索で見つからない状態。

### 解決策
以下の3段階の検索方法を実装：

1. **GraphQL API (最優先)**
   - `CrossReferencedEvent`を使用してIssueとPRの関連を確実に検出
   - 最も信頼性が高い方法

2. **単純な番号検索 (フォールバック1)**
   - PR本文にIssue番号が記載されているかを検索
   - `fixes #XXX`, `closes #XXX`などのパターンに対応

3. **ブランチ名パターン検索 (フォールバック2)**
   - `issue-XXX`, `fix-XXX`, `feature-XXX`などのパターンで検索
   - ブランチ名にIssue番号が含まれるケースに対応

## 主な変更点

### 新規ファイル
- `internal/github/pull_request_graphql.go` - GraphQL APIによるPR検索
- `internal/github/pull_request_search.go` - 包括的なPR検索機能
- `internal/github/pull_request_fallback.go` - ブランチ名による検索
- `internal/github/repo_info.go` - リポジトリ情報管理

### 既存ファイルの変更
- `internal/github/pull_request.go` - 複数の検索方法を試すように改良
- `internal/github/client.go` - owner/repo情報の管理追加
- `internal/watcher/auto_merge.go` - フォールバック機能の統合

## 動作確認

実環境での検証結果：
- Issue #227 → PR #230を正しく検出（GraphQL経由）
- Issue #217 → マージ済みのため検出なし（期待通り）
- Issue #228 → PRなしのため検出なし（期待通り）

ご確認のほどよろしくお願いいたします。