### PR TITLE
feat: PRへのstatus:requires-changesラベル付与対応 (#266)

### DIFF
--- a/.claude/commands/osoba/review.md
+++ b/.claude/commands/osoba/review.md
@@ -81,15 +81,16 @@ After posting the review result, update the labels based on the verdict:
 
 #### If Approved (LGTM):
 1. Keep `status:reviewing` label on the Issue (Issue lifecycle ends here)
-2. Add `status:lgtm` label to the Pull Request:
+2. Remove `status:requires-changes` label from the Pull Request (if exists) and add `status:lgtm` label:
    ```bash
-   gh pr edit <PR number> --add-label "status:lgtm"
+   gh pr edit <PR number> --remove-label "status:requires-changes" --add-label "status:lgtm"
    ```
 
 #### If Requires Changes:
-1. Update Issue labels (remove `status:reviewing` and add `status:requires-changes`):
+1. Keep `status:reviewing` label on the Issue (Issue remains in review state)
+2. Add `status:requires-changes` label to the Pull Request:
    ```bash
-   gh issue edit <issue number> --remove-label "status:reviewing" --add-label "status:requires-changes"
+   gh pr edit <PR number> --add-label "status:requires-changes"
    ```
 
 ## Basic Rules

--- a/cmd/templates/commands/review.md
+++ b/cmd/templates/commands/review.md
@@ -81,15 +81,16 @@ After posting the review result, update the labels based on the verdict:
 
 #### If Approved (LGTM):
 1. Keep `status:reviewing` label on the Issue (Issue lifecycle ends here)
-2. Add `status:lgtm` label to the Pull Request:
+2. Remove `status:requires-changes` label from the Pull Request (if exists) and add `status:lgtm` label:
    ```bash
-   gh pr edit <PR number> --add-label "status:lgtm"
+   gh pr edit <PR number> --remove-label "status:requires-changes" --add-label "status:lgtm"
    ```
 
 #### If Requires Changes:
-1. Update Issue labels (remove `status:reviewing` and add `status:requires-changes`):
+1. Keep `status:reviewing` label on the Issue (Issue remains in review state)
+2. Add `status:requires-changes` label to the Pull Request:
    ```bash
-   gh issue edit <issue number> --remove-label "status:reviewing" --add-label "status:requires-changes"
+   gh pr edit <PR number> --add-label "status:requires-changes"
    ```
 
 ## Basic Rules

--- a/docs/development/label-transition-spec.md
+++ b/docs/development/label-transition-spec.md
@@ -48,7 +48,9 @@ if err := w.executeLabelTransition(ctx, issue); err != nil {
 |-------------|-------------|------------|
 | `status:review-requested` | `status:reviewing` | Issue に `status:review-requested` ラベルが存在する |
 
-**Note**: レビュー承認時（LGTM）の場合、Issueは`status:reviewing`ラベルを維持し、PRに`status:lgtm`ラベルが付与されます。
+**Note**: レビュー結果のラベルはPRに付与されます：
+- 承認時（LGTM）: Issueは`status:reviewing`ラベルを維持し、PRに`status:lgtm`ラベルが付与されます
+- 修正要求時: Issueは`status:reviewing`ラベルを維持し、PRに`status:requires-changes`ラベルが付与されます
 
 ### 4. 再実装フェーズ (Re-implementation Phase)
 
@@ -146,15 +148,18 @@ Issueは開発タスクの管理単位として、以下のライフサイクル
 2. `status:ready` → `status:implementing` → `status:review-requested`
 3. `status:review-requested` → `status:reviewing`
 4. レビュー結果により：
-   - 承認時: `status:reviewing` で終了（PRにマージ判断が移る）
-   - 修正要求時: `status:requires-changes` → `status:ready`（再実装へ）
+   - 承認時: `status:reviewing` を維持（PRにマージ判断が移る）
+   - 修正要求時: `status:reviewing` を維持（PRに`status:requires-changes`が付与される）
 
 ### PR のライフサイクル
 
 PRは実装結果の管理単位として、以下のラベルを持ちます：
 
 - `status:lgtm`: レビュー承認済み、マージ可能
+- `status:requires-changes`: レビューで修正要求あり、再実装が必要
 - 将来的に他のPR専用ラベルを追加可能
+
+**Note**: レビュー結果は主にPRのラベルで管理され、Issueは`status:reviewing`を維持します。
 
 ### 自動マージ機能への影響
 

--- a/internal/watcher/integration_pr_test.go
+++ b/internal/watcher/integration_pr_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -253,9 +254,9 @@ func TestPRWatcherHealthMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	var callCount int
+	var callCount int32
 	callback := func(pr *github.PullRequest) {
-		callCount++
+		atomic.AddInt32(&callCount, 1)
 	}
 
 	// Start メソッドで実行

--- a/internal/watcher/retry_test.go
+++ b/internal/watcher/retry_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,10 +31,10 @@ func TestRetryWithBackoff(t *testing.T) {
 			name:       "正常系: 2回目で成功",
 			maxRetries: 3,
 			operation: func() func() error {
-				attempt := 0
+				var attempt int32
 				return func() error {
-					attempt++
-					if attempt < 2 {
+					currentAttempt := atomic.AddInt32(&attempt, 1)
+					if currentAttempt < 2 {
 						// リトライ可能なエラーを返す
 						return &github.RateLimitError{
 							Message: "API rate limit exceeded",


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #266
- 対応内容:
  - review.mdテンプレートを更新し、レビューNG時にPRへ`status:requires-changes`ラベルを付与するよう変更
  - レビューOK時に既存の`status:requires-changes`ラベルを削除してから`status:lgtm`を付与するよう変更
  - .claude/commands/osoba/review.mdも同様に更新
  - ラベル遷移仕様書を更新し、PRのライフサイクルに`status:requires-changes`を追加
  - Issueは`status:reviewing`ラベルを維持し、レビュー結果はPRのラベルで管理するよう仕様を明確化
- 実装方式: プロンプトベースの実装（テンプレート修正）
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス  
  - フルテスト: ✅ パス
- 関連PR: このPR

ご確認のほどよろしくお願いいたします。