### PR TITLE
feat: レビュー指摘対応用reviseアクションの追加 (#267)

### DIFF
--- a/cmd/templates/commands/revise.md
+++ b/cmd/templates/commands/revise.md
@@ -1,0 +1,156 @@
+---
+allowed-tools: TodoRead, TodoWrite, Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS
+description: "Revise implementation based on review feedback"
+---
+
+## Overview
+
+You are a skilled developer responsible for addressing review feedback and fixing issues found during the code review process.  
+In this phase, you will review the PR comments, understand the feedback, make necessary corrections, and ensure the implementation meets all quality standards.
+
+---
+
+## Prerequisites
+
+### Documents
+
+Refer to the following documentation:
+
+- **Coding Standards**: @docs/development/coding-standards.md
+- **Testing Strategy**: @docs/development/testing-strategy.md
+- **Other Development Documents**: @docs/development/INDEX.md
+
+### Expected state of the Issue
+
+- A Pull Request exists with review comments
+- The PR has "status:requires-changes" label
+- Acceptance criteria remain unchanged
+
+---
+
+## Rules
+
+1. Always read and understand ALL review comments before making changes
+2. Address each review comment systematically  
+3. Follow TDD when adding or modifying tests
+4. Respect the existing design and architecture
+5. After addressing all feedback, the PR should be ready for re-review
+6. Update the Issue label to "status:review-requested" when complete
+7. If the current directory is under `.git/osoba/`, this is a dedicated codebase created using git worktree
+
+---
+
+## Instructions
+
+### Workflow (Overview)
+
+1. Check the PR and review comments
+2. Understand all feedback points
+3. Make necessary corrections
+4. Run tests to verify fixes
+5. Commit changes with clear messages
+6. Post a summary of changes made
+7. Update Issue labels
+
+---
+
+## Detailed Steps
+
+1. **Check the Pull Request and review comments**
+   - Run `gh pr list --author @me --state open` to find your PR
+   - Run `gh pr view <PR number>` to see PR details
+   - Run `gh pr view <PR number> --comments` to read all review comments
+   - Make a list of all feedback points that need to be addressed
+
+2. **Understand the feedback**
+   - Categorize feedback into:
+     - Code quality issues
+     - Bug fixes
+     - Test coverage gaps
+     - Documentation updates
+     - Style/formatting issues
+   - Prioritize critical issues first
+
+3. **Make corrections systematically**
+   - Address each feedback point one by one
+   - Write/update tests as needed
+   - Ensure each change maintains backward compatibility
+   - Commit frequently with descriptive messages like:
+     ```
+     fix: address review feedback on error handling
+     refactor: improve variable naming as suggested
+     test: add missing test cases for edge conditions
+     ```
+
+4. **Run tests and verify**
+   - Run the full test suite to ensure nothing is broken
+   - Verify that all review points have been addressed
+   - Check that the code still meets the original requirements
+
+5. **Post a summary comment**
+   - Create a comment on the PR summarizing what was changed:
+   ```bash
+   gh pr comment <PR number> --body "## レビュー指摘対応完了
+
+   以下の指摘事項に対応しました：
+   - ✅ [対応した項目1]
+   - ✅ [対応した項目2]
+   - ✅ [対応した項目3]
+
+   全てのテストがパスすることを確認済みです。
+   再レビューをお願いいたします。"
+   ```
+
+6. **Update Issue labels**
+   - Remove "status:revising" label
+   - Add "status:review-requested" label
+   ```bash
+   gh issue edit <issue number> \
+     --remove-label "status:revising" \
+     --add-label "status:review-requested"
+   ```
+
+---
+
+## Common Review Feedback Types
+
+### Code Quality
+- Variable/function naming improvements
+- Code duplication removal
+- Complex logic simplification
+- Error handling improvements
+
+### Testing
+- Missing test cases
+- Edge case coverage
+- Test data improvements
+- Mock simplification
+
+### Documentation
+- Missing or unclear comments
+- API documentation updates
+- README updates
+
+### Performance
+- Inefficient algorithms
+- Unnecessary database queries
+- Memory leak risks
+
+---
+
+## Best Practices
+
+1. **Be thorough**: Address ALL feedback, not just the easy ones
+2. **Be communicative**: If you disagree with feedback, explain why
+3. **Be proactive**: Look for similar issues elsewhere in the code
+4. **Be respectful**: Thank reviewers for their feedback
+5. **Be complete**: Ensure all tests pass before marking as ready
+
+---
+
+## Important Notes
+
+- Never mark as "ready for review" if tests are failing
+- If you cannot address certain feedback, explain why in the PR comments
+- Keep the commit history clean and meaningful
+- Always verify the changes work as expected before updating labels

--- a/internal/claude/config.go
+++ b/internal/claude/config.go
@@ -27,6 +27,10 @@ func NewDefaultClaudeConfig() *ClaudeConfig {
 				Args:   []string{"--dangerously-skip-permissions"},
 				Prompt: "/osoba:review {{issue-number}}",
 			},
+			"revise": {
+				Args:   []string{"--dangerously-skip-permissions"},
+				Prompt: "/osoba:revise {{issue-number}}",
+			},
 		},
 	}
 }

--- a/internal/types/action.go
+++ b/internal/types/action.go
@@ -7,6 +7,7 @@ const (
 	ActionTypePlan           ActionType = "plan"
 	ActionTypeImplementation ActionType = "implementation"
 	ActionTypeReview         ActionType = "review"
+	ActionTypeRevise         ActionType = "revise"
 )
 
 // BaseAction はActionExecutorの基本実装

--- a/internal/watcher/action_factory.go
+++ b/internal/watcher/action_factory.go
@@ -15,6 +15,7 @@ type ActionFactory interface {
 	CreatePlanAction() ActionExecutor
 	CreateImplementationAction() ActionExecutor
 	CreateReviewAction() ActionExecutor
+	CreateReviseAction() ActionExecutor
 	CreateNoOpAction() ActionExecutor
 }
 
@@ -109,7 +110,26 @@ func (f *DefaultActionFactory) CreateReviewAction() ActionExecutor {
 	)
 }
 
-// CreateNoOpAction は何もしないアクションを作成する（status:requires-changes用）
+// CreateReviseAction はレビュー指摘対応フェーズのアクションを作成する
+func (f *DefaultActionFactory) CreateReviseAction() ActionExecutor {
+	labelManager := &actions.DefaultLabelManager{
+		GitHubClient: f.ghClient,
+		Owner:        f.owner,
+		Repo:         f.repo,
+	}
+
+	return actions.NewReviseAction(
+		f.sessionName,
+		f.tmuxManager,
+		labelManager,
+		f.worktreeManager,
+		f.claudeExecutor,
+		f.claudeConfig,
+		f.logger.WithFields("component", "ReviseAction"),
+	)
+}
+
+// CreateNoOpAction は何もしないアクションを作成する
 func (f *DefaultActionFactory) CreateNoOpAction() ActionExecutor {
 	return NewNoOpAction(f.logger.WithFields("component", "NoOpAction"))
 }

--- a/internal/watcher/action_manager_extended.go
+++ b/internal/watcher/action_manager_extended.go
@@ -58,7 +58,7 @@ func (m *ActionManagerExtended) GetActionForIssue(issue *github.Issue) ActionExe
 		return m.factory.CreateReviewAction()
 	}
 	if hasLabel(issue, "status:requires-changes") {
-		return m.factory.CreateNoOpAction()
+		return m.factory.CreateReviseAction()
 	}
 
 	return nil

--- a/internal/watcher/action_manager_requires_changes_test.go
+++ b/internal/watcher/action_manager_requires_changes_test.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/douhashi/osoba/internal/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestActionManagerExtended_RequiresChanges(t *testing.T) {
-	t.Run("returns NoOpAction for status:requires-changes label", func(t *testing.T) {
+	t.Run("returns ReviseAction for status:requires-changes label", func(t *testing.T) {
 		// モックファクトリーを作成
 		mockFactory := new(MockActionFactory)
-		noOpAction := NewNoOpAction(NewMockLogger())
-		mockFactory.On("CreateNoOpAction").Return(noOpAction)
+		mockReviseAction := new(MockActionExecutorExt)
+		mockFactory.On("CreateReviseAction").Return(mockReviseAction)
 
 		// ActionManagerを作成
 		manager := NewActionManagerExtended("test-session", mockFactory)
@@ -29,20 +30,20 @@ func TestActionManagerExtended_RequiresChanges(t *testing.T) {
 		// アクションを取得
 		action := manager.GetActionForIssue(issue)
 
-		// NoOpActionが返されることを確認
+		// ReviseActionが返されることを確認
 		assert.NotNil(t, action)
-		// NoOpActionの型であることを確認
-		_, ok := action.(*NoOpAction)
-		assert.True(t, ok, "Expected NoOpAction type")
+		assert.Equal(t, mockReviseAction, action)
 
 		mockFactory.AssertExpectations(t)
 	})
 
-	t.Run("executes NoOpAction successfully", func(t *testing.T) {
+	t.Run("executes ReviseAction successfully", func(t *testing.T) {
 		// モックファクトリーを作成
 		mockFactory := new(MockActionFactory)
-		noOpAction := NewNoOpAction(NewMockLogger())
-		mockFactory.On("CreateNoOpAction").Return(noOpAction)
+		mockReviseAction := new(MockActionExecutorExt)
+		mockReviseAction.On("CanExecute", mock.Anything).Return(true)
+		mockReviseAction.On("Execute", mock.Anything, mock.Anything).Return(nil)
+		mockFactory.On("CreateReviseAction").Return(mockReviseAction)
 
 		// ActionManagerを作成
 		manager := NewActionManagerExtended("test-session", mockFactory)
@@ -62,5 +63,6 @@ func TestActionManagerExtended_RequiresChanges(t *testing.T) {
 		assert.NoError(t, err)
 
 		mockFactory.AssertExpectations(t)
+		mockReviseAction.AssertExpectations(t)
 	})
 }

--- a/internal/watcher/action_manager_test.go
+++ b/internal/watcher/action_manager_test.go
@@ -53,6 +53,14 @@ func (m *MockActionFactory) CreateReviewAction() ActionExecutor {
 	return args.Get(0).(ActionExecutor)
 }
 
+func (m *MockActionFactory) CreateReviseAction() ActionExecutor {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(ActionExecutor)
+}
+
 func (m *MockActionFactory) CreateNoOpAction() ActionExecutor {
 	args := m.Called()
 	if args.Get(0) == nil {

--- a/internal/watcher/actions/revise_action.go
+++ b/internal/watcher/actions/revise_action.go
@@ -1,0 +1,131 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/douhashi/osoba/internal/claude"
+	"github.com/douhashi/osoba/internal/git"
+	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/logger"
+	tmuxpkg "github.com/douhashi/osoba/internal/tmux"
+	"github.com/douhashi/osoba/internal/types"
+)
+
+// ReviseAction はpane管理方式を使用するレビュー指摘対応フェーズのアクション実装
+type ReviseAction struct {
+	types.BaseAction
+	baseExecutor   *BaseExecutor
+	claudeExecutor claude.ClaudeExecutor
+	sessionName    string
+	labelManager   ActionsLabelManager
+	claudeConfig   *claude.ClaudeConfig
+	logger         logger.Logger
+}
+
+// NewReviseAction は新しいReviseActionを作成する
+func NewReviseAction(
+	sessionName string,
+	tmuxManager tmuxpkg.Manager,
+	labelManager ActionsLabelManager,
+	worktreeManager git.WorktreeManager,
+	claudeExecutor claude.ClaudeExecutor,
+	claudeConfig *claude.ClaudeConfig,
+	logger logger.Logger,
+) *ReviseAction {
+	baseExecutor := NewBaseExecutor(
+		sessionName,
+		tmuxManager,
+		worktreeManager,
+		nil, // ClaudeCommandBuilderは不要になったのでnilを渡す
+		logger,
+	)
+
+	return &ReviseAction{
+		BaseAction:     types.BaseAction{Type: types.ActionTypeRevise},
+		baseExecutor:   baseExecutor,
+		claudeExecutor: claudeExecutor,
+		sessionName:    sessionName,
+		labelManager:   labelManager,
+		claudeConfig:   claudeConfig,
+		logger:         logger,
+	}
+}
+
+// Execute はレビュー指摘対応フェーズのアクションを実行する
+func (a *ReviseAction) Execute(ctx context.Context, issue *github.Issue) error {
+	if issue == nil || issue.Number == nil {
+		return fmt.Errorf("invalid issue")
+	}
+
+	issueNumber := int64(*issue.Number)
+	a.logger.Info("Executing revise action", "issue_number", issueNumber)
+
+	// ワークスペースの準備（既存のものを再利用）
+	workspace, err := a.baseExecutor.PrepareWorkspace(ctx, issue, "Revise")
+	if err != nil {
+		return fmt.Errorf("failed to prepare workspace: %w", err)
+	}
+
+	a.logger.Info("Workspace prepared",
+		"issue_number", issueNumber,
+		"window_name", workspace.WindowName,
+		"worktree_path", workspace.WorktreePath,
+		"pane_index", workspace.PaneIndex,
+	)
+
+	// Claude実行用の変数を準備
+	templateVars := &claude.TemplateVariables{
+		IssueNumber: int(issueNumber),
+		IssueTitle:  getIssueTitle(issue),
+		RepoName:    getRepoName(),
+	}
+
+	// Claude設定を取得
+	phaseConfig, exists := a.claudeConfig.GetPhase("revise")
+	if !exists {
+		return fmt.Errorf("revise phase config not found")
+	}
+
+	// ClaudeExecutorを使用してtmuxウィンドウ内で実行
+	a.logger.Info("Executing Claude in tmux window",
+		"issue_number", issueNumber,
+		"session", a.sessionName,
+		"window", workspace.WindowName,
+		"worktree_path", workspace.WorktreePath,
+	)
+
+	if err := a.claudeExecutor.ExecuteInTmux(ctx, phaseConfig, templateVars, a.sessionName, workspace.WindowName, workspace.WorktreePath); err != nil {
+		return fmt.Errorf("failed to execute Claude command: %w", err)
+	}
+
+	// ラベル更新: status:requires-changes -> status:revising
+	if a.labelManager != nil {
+		a.logger.Info("Updating issue labels", "issue_number", issueNumber)
+		if err := a.labelManager.RemoveLabel(ctx, int(issueNumber), "status:requires-changes"); err != nil {
+			a.logger.Error("Failed to remove label",
+				"issue_number", issueNumber,
+				"label", "status:requires-changes",
+				"error", err,
+			)
+		}
+		if err := a.labelManager.AddLabel(ctx, int(issueNumber), "status:revising"); err != nil {
+			a.logger.Error("Failed to add label",
+				"issue_number", issueNumber,
+				"label", "status:revising",
+				"error", err,
+			)
+		}
+	}
+
+	a.logger.Info("Revise action completed successfully", "issue_number", issueNumber)
+
+	// V2ではフェーズ遷移は行わない（別のコンポーネントが管理）
+
+	return nil
+}
+
+// CanExecute はレビュー指摘対応フェーズのアクションが実行可能かを判定する
+func (a *ReviseAction) CanExecute(issue *github.Issue) bool {
+	return hasLabel(issue, "status:requires-changes")
+}

--- a/internal/watcher/actions/revise_action_test.go
+++ b/internal/watcher/actions/revise_action_test.go
@@ -1,0 +1,249 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douhashi/osoba/internal/claude"
+	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/testutil/builders"
+	"github.com/douhashi/osoba/internal/testutil/helpers"
+	"github.com/douhashi/osoba/internal/testutil/mocks"
+	tmuxpkg "github.com/douhashi/osoba/internal/tmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestReviseAction_Execute(t *testing.T) {
+	tests := []struct {
+		name         string
+		issue        *github.Issue
+		setupMocks   func(*mocks.MockTmuxManager, *mocks.MockGitWorktreeManager, *mocks.MockClaudeExecutor, *mocks.MockLabelManager)
+		claudeConfig *claude.ClaudeConfig
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name: "正常なReviseアクション実行",
+			issue: builders.NewIssueBuilder().
+				WithNumber(123).
+				WithTitle("Test Issue").
+				WithLabel("status:requires-changes").
+				Build(),
+			setupMocks: func(tmux *mocks.MockTmuxManager, git *mocks.MockGitWorktreeManager, claudeExec *mocks.MockClaudeExecutor, labelManager *mocks.MockLabelManager) {
+				// PrepareWorkspace - 既存のワークスペースを再利用
+				tmux.On("SessionExists", "test-session").Return(true, nil).Once()
+				tmux.On("WindowExists", "test-session", "issue-123").Return(true, nil).Once()
+				git.On("WorktreeExistsForIssue", mock.Anything, 123).Return(true, nil).Once()
+				tmux.On("GetPaneByTitle", "test-session", "issue-123", "Revise").Return(nil, assert.AnError).Once()
+				// Reviseフェーズでは新しいpaneを作成
+				tmux.On("CreatePane", "test-session", "issue-123", mock.Anything).
+					Return(&tmuxpkg.PaneInfo{Index: 2, Title: "Revise", Active: true}, nil).Once()
+				git.On("GetWorktreePathForIssue", 123).Return("/test/worktree/issue-123").Once()
+
+				// Claude実行 - ExecuteInTmuxを使用
+				expectedConfig := &claude.PhaseConfig{
+					Prompt: "/osoba:revise {{issue-number}}",
+					Args:   []string{"--dangerously-skip-permissions"},
+				}
+				expectedVars := &claude.TemplateVariables{
+					IssueNumber: 123,
+					IssueTitle:  "Test Issue",
+					RepoName:    "osoba",
+				}
+				claudeExec.On("ExecuteInTmux",
+					mock.Anything,
+					expectedConfig,
+					mock.MatchedBy(func(vars *claude.TemplateVariables) bool {
+						return vars.IssueNumber == expectedVars.IssueNumber &&
+							vars.IssueTitle == expectedVars.IssueTitle
+					}),
+					"test-session",
+					"issue-123",
+					"/test/worktree/issue-123",
+				).Return(nil).Once()
+
+				// ラベル更新
+				labelManager.On("RemoveLabel", mock.Anything, 123, "status:requires-changes").Return(nil).Once()
+				labelManager.On("AddLabel", mock.Anything, 123, "status:revising").Return(nil).Once()
+			},
+			claudeConfig: &claude.ClaudeConfig{
+				Phases: map[string]*claude.PhaseConfig{
+					"revise": {
+						Prompt: "/osoba:revise {{issue-number}}",
+						Args:   []string{"--dangerously-skip-permissions"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "nilのissue",
+			issue: nil,
+			setupMocks: func(tmux *mocks.MockTmuxManager, git *mocks.MockGitWorktreeManager, claudeExec *mocks.MockClaudeExecutor, labelManager *mocks.MockLabelManager) {
+				// 何も呼ばれない
+			},
+			claudeConfig: &claude.ClaudeConfig{},
+			wantErr:      true,
+			errContains:  "invalid issue",
+		},
+		{
+			name: "issue numberがnil",
+			issue: &github.Issue{
+				Title: github.String("Test Issue"),
+			},
+			setupMocks: func(tmux *mocks.MockTmuxManager, git *mocks.MockGitWorktreeManager, claudeExec *mocks.MockClaudeExecutor, labelManager *mocks.MockLabelManager) {
+				// 何も呼ばれない
+			},
+			claudeConfig: &claude.ClaudeConfig{},
+			wantErr:      true,
+			errContains:  "invalid issue",
+		},
+		{
+			name: "phase設定が見つからない",
+			issue: builders.NewIssueBuilder().
+				WithNumber(999).
+				WithTitle("No Config").
+				WithLabel("status:requires-changes").
+				Build(),
+			setupMocks: func(tmux *mocks.MockTmuxManager, git *mocks.MockGitWorktreeManager, claudeExec *mocks.MockClaudeExecutor, labelManager *mocks.MockLabelManager) {
+				// PrepareWorkspace
+				tmux.On("SessionExists", "test-session").Return(true, nil).Once()
+				tmux.On("WindowExists", "test-session", "issue-999").Return(true, nil).Once()
+				git.On("WorktreeExistsForIssue", mock.Anything, 999).Return(true, nil).Once()
+				tmux.On("GetPaneByTitle", "test-session", "issue-999", "Revise").Return(nil, assert.AnError).Once()
+				tmux.On("CreatePane", "test-session", "issue-999", mock.Anything).
+					Return(&tmuxpkg.PaneInfo{Index: 1, Title: "Revise", Active: true}, nil).Once()
+				git.On("GetWorktreePathForIssue", 999).Return("/test/worktree/issue-999").Once()
+			},
+			claudeConfig: &claude.ClaudeConfig{
+				Phases: map[string]*claude.PhaseConfig{
+					// reviseフェーズなし
+				},
+			},
+			wantErr:     true,
+			errContains: "revise phase config not found",
+		},
+		{
+			name: "ワークスペース準備失敗",
+			issue: builders.NewIssueBuilder().
+				WithNumber(456).
+				WithTitle("Workspace Error").
+				WithLabel("status:requires-changes").
+				Build(),
+			setupMocks: func(tmux *mocks.MockTmuxManager, git *mocks.MockGitWorktreeManager, claudeExec *mocks.MockClaudeExecutor, labelManager *mocks.MockLabelManager) {
+				tmux.On("SessionExists", "test-session").Return(false, assert.AnError).Once()
+			},
+			claudeConfig: &claude.ClaudeConfig{
+				Phases: map[string]*claude.PhaseConfig{
+					"revise": {
+						Prompt: "/osoba:revise {{issue-number}}",
+						Args:   []string{"--dangerously-skip-permissions"},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "failed to prepare workspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// モックの作成
+			logger, _ := helpers.NewObservableLogger(zapcore.InfoLevel)
+			tmuxManager := mocks.NewMockTmuxManager()
+			worktreeManager := mocks.NewMockGitWorktreeManager()
+			claudeExecutor := mocks.NewMockClaudeExecutor()
+			labelManager := mocks.NewMockLabelManager()
+
+			// モックの設定
+			tt.setupMocks(tmuxManager, worktreeManager, claudeExecutor, labelManager)
+
+			// アクションの作成
+			action := NewReviseAction(
+				"test-session",
+				tmuxManager,
+				labelManager,
+				worktreeManager,
+				claudeExecutor,
+				tt.claudeConfig,
+				logger,
+			)
+
+			// テスト実行
+			err := action.Execute(context.Background(), tt.issue)
+
+			// アサーション
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// モックの呼び出し確認
+			tmuxManager.AssertExpectations(t)
+			worktreeManager.AssertExpectations(t)
+			claudeExecutor.AssertExpectations(t)
+			labelManager.AssertExpectations(t)
+		})
+	}
+}
+
+func TestReviseAction_CanExecute(t *testing.T) {
+	tests := []struct {
+		name     string
+		issue    *github.Issue
+		expected bool
+	}{
+		{
+			name: "status:requires-changesラベルを持つissue",
+			issue: builders.NewIssueBuilder().
+				WithNumber(123).
+				WithLabel("status:requires-changes").
+				Build(),
+			expected: true,
+		},
+		{
+			name: "status:requires-changesラベルを持たないissue",
+			issue: builders.NewIssueBuilder().
+				WithNumber(456).
+				WithLabel("status:ready").
+				Build(),
+			expected: false,
+		},
+		{
+			name: "ラベルなしのissue",
+			issue: builders.NewIssueBuilder().
+				WithNumber(789).
+				Build(),
+			expected: false,
+		},
+		{
+			name:     "nilのissue",
+			issue:    nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := helpers.NewObservableLogger(zapcore.InfoLevel)
+			action := NewReviseAction(
+				"test-session",
+				mocks.NewMockTmuxManager(),
+				mocks.NewMockLabelManager(),
+				mocks.NewMockGitWorktreeManager(),
+				mocks.NewMockClaudeExecutor(),
+				&claude.ClaudeConfig{},
+				logger,
+			)
+
+			result := action.CanExecute(tt.issue)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/watcher/integration_test.go
+++ b/internal/watcher/integration_test.go
@@ -161,6 +161,7 @@ type mockActionFactory struct {
 	planAction           ActionExecutor
 	implementationAction ActionExecutor
 	reviewAction         ActionExecutor
+	reviseAction         ActionExecutor
 	noOpAction           ActionExecutor
 }
 
@@ -174,6 +175,21 @@ func (m *mockActionFactory) CreateImplementationAction() ActionExecutor {
 
 func (m *mockActionFactory) CreateReviewAction() ActionExecutor {
 	return m.reviewAction
+}
+
+func (m *mockActionFactory) CreateReviseAction() ActionExecutor {
+	if m.reviseAction != nil {
+		return m.reviseAction
+	}
+	// デフォルトでNoOpActionを返す（仮の実装）
+	return &mockAction{
+		canExecute: func(issue *github.Issue) bool {
+			return false
+		},
+		execute: func(ctx context.Context, issue *github.Issue) error {
+			return nil
+		},
+	}
 }
 
 func (m *mockActionFactory) CreateNoOpAction() ActionExecutor {


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #267
- 対応内容:
  - ReviseActionクラスを新規作成（レビュー指摘対応専用アクション）
  - revise.mdプロンプトテンプレートを作成（PRレビューコメント確認機能を追加）
  - status:requires-changesラベル検知時の自動実行を実装
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス  
  - フルテスト: ✅ パス

## 変更内容

### 新規ファイル
- `internal/watcher/actions/revise_action.go`: ReviseActionクラスの実装
- `internal/watcher/actions/revise_action_test.go`: ReviseActionのテスト
- `cmd/templates/commands/revise.md`: reviseコマンドのプロンプトテンプレート

### 更新ファイル
- `internal/claude/config.go`: reviseフェーズの設定を追加
- `internal/types/action.go`: ActionTypeRevise定数を追加
- `internal/watcher/action_factory.go`: CreateReviseAction()メソッドを追加
- `internal/watcher/action_manager_extended.go`: status:requires-changes時にReviseActionを使用
- 各種テストファイル: モック実装にCreateReviseAction()を追加

## 詳細

ReviseActionは既存のImplementationActionと同様の構造を持ち、BaseExecutorを利用してワークスペース（tmuxウィンドウ、git worktree）を管理します。主な違いは以下の通りです：

1. PRレビューコメントを確認する専用プロンプト（revise.md）を使用
2. 修正完了後に`status:review-requested`ラベルを付与
3. 既存のワークスペースを再利用して効率的に作業

ご確認のほどよろしくお願いいたします。