### PR TITLE
fix: osoba initでrevise.mdがコピーされない問題を修正

### DIFF
--- a/cmd/.claude/commands/osoba/revise.md
+++ b/cmd/.claude/commands/osoba/revise.md
@@ -1,0 +1,156 @@
+---
+allowed-tools: TodoRead, TodoWrite, Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS
+description: "Revise implementation based on review feedback"
+---
+
+## Overview
+
+You are a skilled developer responsible for addressing review feedback and fixing issues found during the code review process.  
+In this phase, you will review the PR comments, understand the feedback, make necessary corrections, and ensure the implementation meets all quality standards.
+
+---
+
+## Prerequisites
+
+### Documents
+
+Refer to the following documentation:
+
+- **Coding Standards**: @docs/development/coding-standards.md
+- **Testing Strategy**: @docs/development/testing-strategy.md
+- **Other Development Documents**: @docs/development/INDEX.md
+
+### Expected state of the Issue
+
+- A Pull Request exists with review comments
+- The PR has "status:requires-changes" label
+- Acceptance criteria remain unchanged
+
+---
+
+## Rules
+
+1. Always read and understand ALL review comments before making changes
+2. Address each review comment systematically  
+3. Follow TDD when adding or modifying tests
+4. Respect the existing design and architecture
+5. After addressing all feedback, the PR should be ready for re-review
+6. Update the Issue label to "status:review-requested" when complete
+7. If the current directory is under `.git/osoba/`, this is a dedicated codebase created using git worktree
+
+---
+
+## Instructions
+
+### Workflow (Overview)
+
+1. Check the PR and review comments
+2. Understand all feedback points
+3. Make necessary corrections
+4. Run tests to verify fixes
+5. Commit changes with clear messages
+6. Post a summary of changes made
+7. Update Issue labels
+
+---
+
+## Detailed Steps
+
+1. **Check the Pull Request and review comments**
+   - Run `gh pr list --author @me --state open` to find your PR
+   - Run `gh pr view <PR number>` to see PR details
+   - Run `gh pr view <PR number> --comments` to read all review comments
+   - Make a list of all feedback points that need to be addressed
+
+2. **Understand the feedback**
+   - Categorize feedback into:
+     - Code quality issues
+     - Bug fixes
+     - Test coverage gaps
+     - Documentation updates
+     - Style/formatting issues
+   - Prioritize critical issues first
+
+3. **Make corrections systematically**
+   - Address each feedback point one by one
+   - Write/update tests as needed
+   - Ensure each change maintains backward compatibility
+   - Commit frequently with descriptive messages like:
+     ```
+     fix: address review feedback on error handling
+     refactor: improve variable naming as suggested
+     test: add missing test cases for edge conditions
+     ```
+
+4. **Run tests and verify**
+   - Run the full test suite to ensure nothing is broken
+   - Verify that all review points have been addressed
+   - Check that the code still meets the original requirements
+
+5. **Post a summary comment**
+   - Create a comment on the PR summarizing what was changed:
+   ```bash
+   gh pr comment <PR number> --body "## レビュー指摘対応完了
+
+   以下の指摘事項に対応しました：
+   - ✅ [対応した項目1]
+   - ✅ [対応した項目2]
+   - ✅ [対応した項目3]
+
+   全てのテストがパスすることを確認済みです。
+   再レビューをお願いいたします。"
+   ```
+
+6. **Update Issue labels**
+   - Remove "status:revising" label
+   - Add "status:review-requested" label
+   ```bash
+   gh issue edit <issue number> \
+     --remove-label "status:revising" \
+     --add-label "status:review-requested"
+   ```
+
+---
+
+## Common Review Feedback Types
+
+### Code Quality
+- Variable/function naming improvements
+- Code duplication removal
+- Complex logic simplification
+- Error handling improvements
+
+### Testing
+- Missing test cases
+- Edge case coverage
+- Test data improvements
+- Mock simplification
+
+### Documentation
+- Missing or unclear comments
+- API documentation updates
+- README updates
+
+### Performance
+- Inefficient algorithms
+- Unnecessary database queries
+- Memory leak risks
+
+---
+
+## Best Practices
+
+1. **Be thorough**: Address ALL feedback, not just the easy ones
+2. **Be communicative**: If you disagree with feedback, explain why
+3. **Be proactive**: Look for similar issues elsewhere in the code
+4. **Be respectful**: Thank reviewers for their feedback
+5. **Be complete**: Ensure all tests pass before marking as ready
+
+---
+
+## Important Notes
+
+- Never mark as "ready for review" if tests are failing
+- If you cannot address certain feedback, explain why in the PR comments
+- Keep the commit history clean and meaningful
+- Always verify the changes work as expected before updating labels

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -282,7 +282,7 @@ func setupClaudeCommands(out io.Writer) error {
 	}
 
 	// テンプレートファイルの配置
-	files := []string{"plan.md", "implement.md", "review.md", "add-backlog.md"}
+	files := []string{"plan.md", "implement.md", "review.md", "revise.md", "add-backlog.md"}
 	allExist := true
 	someExist := false
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -828,6 +828,7 @@ func TestSetupClaudeCommands(t *testing.T) {
 				".claude/commands/osoba/plan.md":        true,
 				".claude/commands/osoba/implement.md":   true,
 				".claude/commands/osoba/review.md":      true,
+				".claude/commands/osoba/revise.md":      true,
 				".claude/commands/osoba/add-backlog.md": true,
 			},
 		},
@@ -852,6 +853,7 @@ func TestSetupClaudeCommands(t *testing.T) {
 				".claude/commands/osoba/plan.md":        true,
 				".claude/commands/osoba/implement.md":   true,
 				".claude/commands/osoba/review.md":      true,
+				".claude/commands/osoba/revise.md":      true,
 				".claude/commands/osoba/add-backlog.md": true,
 			},
 		},
@@ -880,6 +882,7 @@ func TestSetupClaudeCommands(t *testing.T) {
 			filesCreated: map[string]bool{
 				".claude/commands/osoba/implement.md":   true,
 				".claude/commands/osoba/review.md":      true,
+				".claude/commands/osoba/revise.md":      true,
 				".claude/commands/osoba/add-backlog.md": true,
 			},
 			filesSkipped: map[string]bool{


### PR DESCRIPTION
## 実装完了

`osoba init`で`revise.md`がコピーされない問題について修正しました。

- 対応内容:
  - `setupClaudeCommands`関数の`files`配列に`revise.md`を追加
  - テストケースを更新して`revise.md`が正しく処理されることを確認
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス  
  - フルテスト: ✅ パス

## 詳細

### 問題
`osoba init`コマンドを実行した際、`.claude/commands/osoba/`ディレクトリに以下のファイルはコピーされるが、`revise.md`がコピーされていませんでした：
- plan.md
- implement.md
- review.md
- add-backlog.md

### 原因
`cmd/init.go`の`setupClaudeCommands`関数内で定義されている`files`配列に`revise.md`が含まれていませんでした。

### 修正内容
1. **`cmd/init.go`**: `files`配列に`revise.md`を追加
2. **`cmd/init_test.go`**: テストケースを更新し、`revise.md`のファイル作成・スキップ処理を正しく検証

### テスト結果
- `TestSetupClaudeCommands`: 全てのテストケースが通過
- `TestInit*`: 全てのinit関連テストが通過

ご確認のほどよろしくお願いいたします。