### PR TITLE
fix: osoba initでrevise設定とstatus:revisingラベルが作成されるように修正

### DIFF
--- a/.claude/commands/osoba/revise.md
+++ b/.claude/commands/osoba/revise.md
@@ -1,0 +1,156 @@
+---
+allowed-tools: TodoRead, TodoWrite, Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS
+description: "Revise implementation based on review feedback"
+---
+
+## Overview
+
+You are a skilled developer responsible for addressing review feedback and fixing issues found during the code review process.  
+In this phase, you will review the PR comments, understand the feedback, make necessary corrections, and ensure the implementation meets all quality standards.
+
+---
+
+## Prerequisites
+
+### Documents
+
+Refer to the following documentation:
+
+- **Coding Standards**: @docs/development/coding-standards.md
+- **Testing Strategy**: @docs/development/testing-strategy.md
+- **Other Development Documents**: @docs/development/INDEX.md
+
+### Expected state of the Issue
+
+- A Pull Request exists with review comments
+- The PR has "status:requires-changes" label
+- Acceptance criteria remain unchanged
+
+---
+
+## Rules
+
+1. Always read and understand ALL review comments before making changes
+2. Address each review comment systematically  
+3. Follow TDD when adding or modifying tests
+4. Respect the existing design and architecture
+5. After addressing all feedback, the PR should be ready for re-review
+6. Update the Issue label to "status:review-requested" when complete
+7. If the current directory is under `.git/osoba/`, this is a dedicated codebase created using git worktree
+
+---
+
+## Instructions
+
+### Workflow (Overview)
+
+1. Check the PR and review comments
+2. Understand all feedback points
+3. Make necessary corrections
+4. Run tests to verify fixes
+5. Commit changes with clear messages
+6. Post a summary of changes made
+7. Update Issue labels
+
+---
+
+## Detailed Steps
+
+1. **Check the Pull Request and review comments**
+   - Run `gh pr list --author @me --state open` to find your PR
+   - Run `gh pr view <PR number>` to see PR details
+   - Run `gh pr view <PR number> --comments` to read all review comments
+   - Make a list of all feedback points that need to be addressed
+
+2. **Understand the feedback**
+   - Categorize feedback into:
+     - Code quality issues
+     - Bug fixes
+     - Test coverage gaps
+     - Documentation updates
+     - Style/formatting issues
+   - Prioritize critical issues first
+
+3. **Make corrections systematically**
+   - Address each feedback point one by one
+   - Write/update tests as needed
+   - Ensure each change maintains backward compatibility
+   - Commit frequently with descriptive messages like:
+     ```
+     fix: address review feedback on error handling
+     refactor: improve variable naming as suggested
+     test: add missing test cases for edge conditions
+     ```
+
+4. **Run tests and verify**
+   - Run the full test suite to ensure nothing is broken
+   - Verify that all review points have been addressed
+   - Check that the code still meets the original requirements
+
+5. **Post a summary comment**
+   - Create a comment on the PR summarizing what was changed:
+   ```bash
+   gh pr comment <PR number> --body "## レビュー指摘対応完了
+
+   以下の指摘事項に対応しました：
+   - ✅ [対応した項目1]
+   - ✅ [対応した項目2]
+   - ✅ [対応した項目3]
+
+   全てのテストがパスすることを確認済みです。
+   再レビューをお願いいたします。"
+   ```
+
+6. **Update Issue labels**
+   - Remove "status:revising" label
+   - Add "status:review-requested" label
+   ```bash
+   gh issue edit <issue number> \
+     --remove-label "status:revising" \
+     --add-label "status:review-requested"
+   ```
+
+---
+
+## Common Review Feedback Types
+
+### Code Quality
+- Variable/function naming improvements
+- Code duplication removal
+- Complex logic simplification
+- Error handling improvements
+
+### Testing
+- Missing test cases
+- Edge case coverage
+- Test data improvements
+- Mock simplification
+
+### Documentation
+- Missing or unclear comments
+- API documentation updates
+- README updates
+
+### Performance
+- Inefficient algorithms
+- Unnecessary database queries
+- Memory leak risks
+
+---
+
+## Best Practices
+
+1. **Be thorough**: Address ALL feedback, not just the easy ones
+2. **Be communicative**: If you disagree with feedback, explain why
+3. **Be proactive**: Look for similar issues elsewhere in the code
+4. **Be respectful**: Thank reviewers for their feedback
+5. **Be complete**: Ensure all tests pass before marking as ready
+
+---
+
+## Important Notes
+
+- Never mark as "ready for review" if tests are failing
+- If you cannot address certain feedback, explain why in the PR comments
+- Keep the commit history clean and meaningful
+- Always verify the changes work as expected before updating labels

--- a/cmd/init_revise_config_test.go
+++ b/cmd/init_revise_config_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/douhashi/osoba/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// TestInitCmd_ReviseConfigIncluded は、osoba init で作成される設定ファイルに revise の設定が含まれることを確認する
+func TestInitCmd_ReviseConfigIncluded(t *testing.T) {
+	// テンプレートから設定ファイルの内容を読み込む
+	templateContent, err := templateFS.ReadFile("templates/config.yml")
+	if err != nil {
+		t.Fatalf("Failed to read template: %v", err)
+	}
+
+	// YAML パースして revise 設定があることを確認
+	var configData map[string]interface{}
+	if err := yaml.Unmarshal(templateContent, &configData); err != nil {
+		t.Fatalf("Failed to parse template YAML: %v", err)
+	}
+
+	// claude.phases.revise が存在することを確認
+	claude, ok := configData["claude"].(map[string]interface{})
+	if !ok {
+		t.Fatal("claude section not found in template")
+	}
+
+	phases, ok := claude["phases"].(map[string]interface{})
+	if !ok {
+		t.Fatal("claude.phases section not found in template")
+	}
+
+	revise, ok := phases["revise"].(map[string]interface{})
+	if !ok {
+		t.Fatal("claude.phases.revise section not found in template")
+	}
+
+	// revise フェーズの設定内容を確認
+	args, ok := revise["args"].([]interface{})
+	if !ok {
+		t.Fatal("revise.args not found or not a list")
+	}
+
+	prompt, ok := revise["prompt"].(string)
+	if !ok {
+		t.Fatal("revise.prompt not found or not a string")
+	}
+
+	// 期待する値と比較
+	expectedArgs := []interface{}{"--dangerously-skip-permissions"}
+	expectedPrompt := "/osoba:revise {{issue-number}}"
+
+	if len(args) != len(expectedArgs) {
+		t.Errorf("revise.args length = %d, want %d", len(args), len(expectedArgs))
+	}
+
+	for i, arg := range args {
+		if i < len(expectedArgs) && arg != expectedArgs[i] {
+			t.Errorf("revise.args[%d] = %v, want %v", i, arg, expectedArgs[i])
+		}
+	}
+
+	if prompt != expectedPrompt {
+		t.Errorf("revise.prompt = %v, want %v", prompt, expectedPrompt)
+	}
+}
+
+// TestInitCmd_CreatedConfigContainsRevise は、実際に init コマンドで作成される設定ファイルに revise 設定が含まれることを確認する
+func TestInitCmd_CreatedConfigContainsRevise(t *testing.T) {
+	// テスト用の一時ディレクトリ
+	tempDir := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origWd)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// モック関数の設定
+	origIsGitRepo := isGitRepositoryFunc
+	origCheckCommand := checkCommandFunc
+	origMkdirAll := mkdirAllFunc
+	origWriteFile := writeFileFunc
+	origStat := statFunc
+	origGetGitHubToken := getGitHubTokenFunc
+	defer func() {
+		isGitRepositoryFunc = origIsGitRepo
+		checkCommandFunc = origCheckCommand
+		mkdirAllFunc = origMkdirAll
+		writeFileFunc = origWriteFile
+		statFunc = origStat
+		getGitHubTokenFunc = origGetGitHubToken
+	}()
+
+	var createdFileContent []byte
+	isGitRepositoryFunc = func(path string) (bool, error) {
+		return true, nil
+	}
+	checkCommandFunc = func(cmd string) error {
+		return nil
+	}
+	mkdirAllFunc = func(path string, perm os.FileMode) error {
+		return nil
+	}
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist // ファイルが存在しない
+	}
+	writeFileFunc = func(path string, data []byte, perm os.FileMode) error {
+		if strings.HasSuffix(path, ".osoba.yml") {
+			createdFileContent = make([]byte, len(data))
+			copy(createdFileContent, data)
+		}
+		return nil
+	}
+	getGitHubTokenFunc = func(cfg *config.Config) (string, string) {
+		return "", "" // トークンなし
+	}
+
+	// init コマンドを実行
+	buf := new(bytes.Buffer)
+	rootCmd := newRootCmd()
+	rootCmd.AddCommand(newInitCmd())
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init"})
+
+	err = rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+
+	// 作成されたファイルの内容を確認
+	if len(createdFileContent) == 0 {
+		t.Fatal("config file was not created")
+	}
+
+	// YAML パースして revise 設定があることを確認
+	var configData map[string]interface{}
+	if err := yaml.Unmarshal(createdFileContent, &configData); err != nil {
+		t.Fatalf("Failed to parse created config YAML: %v", err)
+	}
+
+	// claude.phases.revise が存在することを確認
+	claude, ok := configData["claude"].(map[string]interface{})
+	if !ok {
+		t.Fatal("claude section not found in created config")
+	}
+
+	phases, ok := claude["phases"].(map[string]interface{})
+	if !ok {
+		t.Fatal("claude.phases section not found in created config")
+	}
+
+	revise, ok := phases["revise"].(map[string]interface{})
+	if !ok {
+		t.Fatal("claude.phases.revise section not found in created config")
+	}
+
+	// revise フェーズの設定内容を確認
+	prompt, ok := revise["prompt"].(string)
+	if !ok {
+		t.Fatal("revise.prompt not found or not a string")
+	}
+
+	expectedPrompt := "/osoba:revise {{issue-number}}"
+	if prompt != expectedPrompt {
+		t.Errorf("revise.prompt = %v, want %v", prompt, expectedPrompt)
+	}
+}
+
+// TestConfigDefaults_RevisePhaseConfig は、設定ファイルにrevise設定がない場合でもデフォルト値が適用されることを確認する
+func TestConfigDefaults_RevisePhaseConfig(t *testing.T) {
+	// revise設定を含まない設定ファイルの内容
+	configContent := `
+github:
+  poll_interval: 20s
+tmux:
+  session_prefix: "osoba-"
+claude:
+  phases:
+    plan:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:plan {{issue-number}}"
+    implement:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:implement {{issue-number}}"
+    review:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:review {{issue-number}}"
+`
+
+	// 一時ファイルに設定を書き込み
+	tempDir := t.TempDir()
+	configPath := tempDir + "/test-config.yml"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create test config file: %v", err)
+	}
+
+	// 設定を読み込み
+	cfg := config.NewConfig()
+	if err := cfg.Load(configPath); err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// revise フェーズの設定が存在することを確認
+	reviseConfig, exists := cfg.Claude.GetPhase("revise")
+	if !exists {
+		t.Fatal("revise phase config not found after loading config with defaults")
+	}
+
+	// デフォルト値が設定されていることを確認
+	expectedArgs := []string{"--dangerously-skip-permissions"}
+	expectedPrompt := "/osoba:revise {{issue-number}}"
+
+	if len(reviseConfig.Args) != len(expectedArgs) {
+		t.Errorf("revise args length = %d, want %d", len(reviseConfig.Args), len(expectedArgs))
+	}
+
+	for i, arg := range reviseConfig.Args {
+		if i < len(expectedArgs) && arg != expectedArgs[i] {
+			t.Errorf("revise args[%d] = %v, want %v", i, arg, expectedArgs[i])
+		}
+	}
+
+	if reviseConfig.Prompt != expectedPrompt {
+		t.Errorf("revise prompt = %v, want %v", reviseConfig.Prompt, expectedPrompt)
+	}
+}

--- a/cmd/templates/config.yml
+++ b/cmd/templates/config.yml
@@ -24,3 +24,6 @@ claude:
     review:
       args: ["--dangerously-skip-permissions"]
       prompt: "/osoba:review {{issue-number}}"
+    revise:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:revise {{issue-number}}"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type LabelConfig struct {
 	Ready           string `mapstructure:"ready"`
 	Review          string `mapstructure:"review"`
 	RequiresChanges string `mapstructure:"requires_changes"`
+	Revising        string `mapstructure:"revising"`
 }
 
 // PhaseMessageConfig はフェーズ開始時のコメントメッセージ設定
@@ -78,6 +79,7 @@ func NewConfig() *Config {
 				Ready:           "status:ready",
 				Review:          "status:review-requested",
 				RequiresChanges: "status:requires-changes",
+				Revising:        "status:revising",
 			},
 			Messages:      NewDefaultPhaseMessageConfig(),
 			AutoMergeLGTM: true,  // デフォルトで自動マージ機能を有効化
@@ -119,6 +121,7 @@ func (c *Config) Load(configPath string) error {
 	v.SetDefault("github.labels.ready", "status:ready")
 	v.SetDefault("github.labels.review", "status:review-requested")
 	v.SetDefault("github.labels.requires_changes", "status:requires-changes")
+	v.SetDefault("github.labels.revising", "status:revising")
 	v.SetDefault("github.messages.plan", "osoba: 計画を作成します")
 	v.SetDefault("github.messages.implement", "osoba: 実装を開始します")
 	v.SetDefault("github.messages.review", "osoba: レビューを開始します")
@@ -138,6 +141,8 @@ func (c *Config) Load(configPath string) error {
 	v.SetDefault("claude.phases.implement.prompt", "/osoba:implement {{issue-number}}")
 	v.SetDefault("claude.phases.review.args", []string{"--dangerously-skip-permissions"})
 	v.SetDefault("claude.phases.review.prompt", "/osoba:review {{issue-number}}")
+	v.SetDefault("claude.phases.revise.args", []string{"--dangerously-skip-permissions"})
+	v.SetDefault("claude.phases.revise.prompt", "/osoba:revise {{issue-number}}")
 
 	// 設定ファイルを読み込む
 	if err := v.ReadInConfig(); err != nil {
@@ -220,6 +225,9 @@ func (c *Config) Validate() error {
 	if c.GitHub.Labels.RequiresChanges == "" {
 		c.GitHub.Labels.RequiresChanges = "status:requires-changes"
 	}
+	if c.GitHub.Labels.Revising == "" {
+		c.GitHub.Labels.Revising = "status:revising"
+	}
 
 	// tmux設定のバリデーション
 	if c.Tmux.SessionPrefix == "" {
@@ -300,6 +308,7 @@ func (c *Config) GetLabels() []string {
 		c.GitHub.Labels.Ready,
 		c.GitHub.Labels.Review,
 		c.GitHub.Labels.RequiresChanges,
+		c.GitHub.Labels.Revising,
 	}
 }
 
@@ -354,6 +363,9 @@ func (c *Config) SetDefaults() {
 	}
 	if c.GitHub.Labels.RequiresChanges == "" {
 		c.GitHub.Labels.RequiresChanges = "status:requires-changes"
+	}
+	if c.GitHub.Labels.Revising == "" {
+		c.GitHub.Labels.Revising = "status:revising"
 	}
 }
 

--- a/internal/config/config_requires_changes_test.go
+++ b/internal/config/config_requires_changes_test.go
@@ -22,18 +22,20 @@ func TestLabelConfig_RequiresChangesField(t *testing.T) {
 					Ready:           "status:ready",
 					Review:          "status:review-requested",
 					RequiresChanges: "status:requires-changes",
+					Revising:        "status:revising",
 				},
 			},
 		}
 
 		labels := cfg.GetLabels()
 
-		// 4つのラベルが含まれることを確認
-		assert.Len(t, labels, 4)
+		// 5つのラベルが含まれることを確認
+		assert.Len(t, labels, 5)
 		assert.Contains(t, labels, "status:needs-plan")
 		assert.Contains(t, labels, "status:ready")
 		assert.Contains(t, labels, "status:review-requested")
 		assert.Contains(t, labels, "status:requires-changes")
+		assert.Contains(t, labels, "status:revising")
 	})
 
 	t.Run("backward compatibility - empty RequiresChanges field", func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -274,13 +274,14 @@ func TestConfig_GetLabels(t *testing.T) {
 				Ready:           "status:ready",
 				Review:          "status:review-requested",
 				RequiresChanges: "status:requires-changes",
+				Revising:        "status:revising",
 			},
 		},
 	}
 
 	labels := cfg.GetLabels()
 
-	expected := []string{"status:needs-plan", "status:ready", "status:review-requested", "status:requires-changes"}
+	expected := []string{"status:needs-plan", "status:ready", "status:review-requested", "status:requires-changes", "status:revising"}
 	if len(labels) != len(expected) {
 		t.Fatalf("GetLabels() returned %d labels, want %d", len(labels), len(expected))
 	}

--- a/internal/gh/ensure_labels.go
+++ b/internal/gh/ensure_labels.go
@@ -58,6 +58,11 @@ var requiredLabels = []LabelDefinition{
 		Color:       "fbca04",
 		Description: "Changes requested",
 	},
+	{
+		Name:        "status:revising",
+		Color:       "f29513",
+		Description: "Currently addressing review feedback",
+	},
 }
 
 // EnsureLabelsExist は必要なラベルがリポジトリに存在することを保証する

--- a/internal/gh/ensure_labels_test.go
+++ b/internal/gh/ensure_labels_test.go
@@ -23,6 +23,7 @@ func TestClient_EnsureLabelsExist(t *testing.T) {
 		"status:reviewing":        {"e99695", "Currently under review"},
 		"status:lgtm":             {"0e8a16", "Approved"},
 		"status:requires-changes": {"fbca04", "Changes requested"},
+		"status:revising":         {"f29513", "Currently addressing review feedback"},
 	}
 
 	tests := []struct {
@@ -53,6 +54,7 @@ func TestClient_EnsureLabelsExist(t *testing.T) {
 								{"name": "status:reviewing", "color": "e99695", "description": "Currently under review"},
 								{"name": "status:lgtm", "color": "0e8a16", "description": "Approved"},
 								{"name": "status:requires-changes", "color": "fbca04", "description": "Changes requested"},
+								{"name": "status:revising", "color": "f29513", "description": "Currently addressing review feedback"},
 								{"name": "bug", "color": "d73a4a", "description": "Something isn't working"}
 							]`, nil
 						}
@@ -108,8 +110,8 @@ func TestClient_EnsureLabelsExist(t *testing.T) {
 					if callCount == 1 {
 						// 最初の呼び出し: 空のラベル一覧
 						return `[]`, nil
-					} else if callCount <= 9 {
-						// 8つのラベルを作成
+					} else if callCount <= 10 {
+						// 9つのラベルを作成
 						return "", nil
 					}
 					return "", fmt.Errorf("unexpected call count: %d", callCount)


### PR DESCRIPTION
## 実装完了

osoba init時にrevise.mdがコピーされない問題と、status:revisingラベルが作成されない問題を修正しました。

### 対応内容

- **revise設定の追加**: `cmd/templates/config.yml`にreviseフェーズの設定を追加
- **status:revisingラベルの追加**: `internal/gh/ensure_labels.go`にstatus:revisingラベルを追加し、osoba init時に作成されるように修正
- **設定構造の拡張**: `internal/config/config.go`のLabelConfigにRevisingフィールドを追加し、適切なデフォルト値とバリデーションを設定
- **テストの追加**: revise設定が正しく動作することを確認するテストを追加
- **既存テストの更新**: 新しいラベルに対応するようにテストケースを更新

### 実装方式
- TDDに基づきテストを先に作成
- 既存のパターンに従い一貫性を保持
- 設定のデフォルト値とバリデーションを適切に実装

### テスト状況
- 単体テスト: ✅ パス
- 結合テスト: ✅ パス  
- フルテスト: ✅ パス

### 主な変更ファイル
- `cmd/templates/config.yml`: reviseフェーズ設定追加
- `internal/config/config.go`: LabelConfig拡張とデフォルト値設定
- `internal/gh/ensure_labels.go`: status:revisingラベル追加
- `cmd/init_revise_config_test.go`: 新規テストファイル
- テスト修正: 複数のテストファイルを更新

これにより、osoba init実行時にrevise.mdテンプレートとstatus:revisingラベルが確実に作成されるようになりました。

ご確認のほどよろしくお願いいたします。