### PR TITLE
fix: osoba initでstatus:revisingラベルが作成されない問題を修正

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/douhashi/osoba/internal/config"
-	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/gh"
 	"github.com/douhashi/osoba/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -34,7 +34,8 @@ var (
 	statFunc               = os.Stat
 	execCommandFunc        = execCommand
 	createGitHubClientFunc = func(token string) githubInterface {
-		client, _ := github.NewClient(token)
+		executor := gh.NewRealCommandExecutor()
+		client, _ := gh.NewClient(executor)
 		return client
 	}
 	getGitHubRepoInfoFunc = utils.GetGitHubRepoInfo


### PR DESCRIPTION
## Summary
- Issue #280の修正後もstatus:revisingラベルが作成されない問題を解決
- cmd/init.goでinternal/gh.Clientを使用するように修正

## 問題の詳細
Issue #280で`status:revising`ラベルが`requiredLabels`に追加されましたが、`osoba init`実行時に実際にはラベルが作成されていませんでした。

## 根本原因
`cmd/init.go:396`の`createGitHubClientFunc`で`internal/github.NewClient`を呼び出していましたが、これは`internal/github.GHClient`を返し、`EnsureLabelsExist`の実装が`LabelManager`を経由するものでした。一方、`internal/gh.Client`の`EnsureLabelsExist`は直接ラベル作成を行います。

## 修正内容
- `createGitHubClientFunc`で`internal/gh.Client`を使用するように変更
- `gh.NewRealCommandExecutor()`と`gh.NewClient()`を使用

## テスト結果
1. 修正前：`gh label list | grep "status:revising"` → ラベル存在せず
2. `osoba init`実行 → GitHubラベルの作成が成功（✅表示）
3. 修正後：`gh label list | grep "status:revising"` → ラベル正常作成確認

## Test plan
- [x] 既存のinitコマンドテストが全て通ることを確認
- [x] 実際のリポジトリでstatus:revisingラベルが作成されることを確認
- [x] pre-commitチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)