### PR TITLE
fix: revise処理開始時にPRのstatus:requires-changesラベルを削除 (#291)

### DIFF
--- a/internal/testutil/mocks/actions_label_manager.go
+++ b/internal/testutil/mocks/actions_label_manager.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 
+	"github.com/douhashi/osoba/internal/github"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -32,6 +33,15 @@ func (m *MockLabelManager) AddLabel(ctx context.Context, issueNumber int, label 
 func (m *MockLabelManager) RemoveLabel(ctx context.Context, issueNumber int, label string) error {
 	args := m.Called(ctx, issueNumber, label)
 	return args.Error(0)
+}
+
+// GetPullRequestForIssue はIssueに関連するPRを取得する
+func (m *MockLabelManager) GetPullRequestForIssue(ctx context.Context, issueNumber int) (*github.PullRequest, error) {
+	args := m.Called(ctx, issueNumber)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*github.PullRequest), args.Error(1)
 }
 
 // WithSuccessfulTransition は成功するTransitionLabelの期待値を設定

--- a/internal/watcher/actions/github_adapter.go
+++ b/internal/watcher/actions/github_adapter.go
@@ -60,6 +60,21 @@ func (a *GitHubAdapter) TransitionLabel(ctx context.Context, issueNumber int, fr
 	return nil
 }
 
+// AddLabel はラベルを追加する
+func (a *GitHubAdapter) AddLabel(ctx context.Context, issueNumber int, label string) error {
+	return a.client.AddLabel(ctx, a.owner, a.repo, issueNumber, label)
+}
+
+// RemoveLabel はラベルを削除する
+func (a *GitHubAdapter) RemoveLabel(ctx context.Context, issueNumber int, label string) error {
+	return a.client.RemoveLabel(ctx, a.owner, a.repo, issueNumber, label)
+}
+
+// GetPullRequestForIssue はIssueに関連するPRを取得する
+func (a *GitHubAdapter) GetPullRequestForIssue(ctx context.Context, issueNumber int) (*github.PullRequest, error) {
+	return a.client.GetPullRequestForIssue(ctx, issueNumber)
+}
+
 // ConfigAdapter はconfig.Configをactions.ConfigProviderに適合させるアダプター
 type ConfigAdapter struct {
 	config *config.Config

--- a/internal/watcher/actions/label_manager.go
+++ b/internal/watcher/actions/label_manager.go
@@ -12,6 +12,7 @@ type ActionsLabelManager interface {
 	TransitionLabel(ctx context.Context, issueNumber int, from, to string) error
 	AddLabel(ctx context.Context, issueNumber int, label string) error
 	RemoveLabel(ctx context.Context, issueNumber int, label string) error
+	GetPullRequestForIssue(ctx context.Context, issueNumber int) (*github.PullRequest, error)
 }
 
 // DefaultLabelManager はデフォルトのラベル管理実装
@@ -56,4 +57,13 @@ func (m *DefaultLabelManager) RemoveLabel(ctx context.Context, issueNumber int, 
 	}
 
 	return m.GitHubClient.RemoveLabel(ctx, m.Owner, m.Repo, issueNumber, label)
+}
+
+// GetPullRequestForIssue はIssueに関連するPRを取得する
+func (m *DefaultLabelManager) GetPullRequestForIssue(ctx context.Context, issueNumber int) (*github.PullRequest, error) {
+	if m.GitHubClient == nil {
+		return nil, fmt.Errorf("GitHub client is not initialized")
+	}
+
+	return m.GitHubClient.GetPullRequestForIssue(ctx, issueNumber)
 }


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #291
- 対応内容:
  - ActionsLabelManagerインターフェースにGetPullRequestForIssueメソッドを追加
  - GitHubAdapterとDefaultLabelManagerにGetPullRequestForIssue実装を追加
  - ReviseAction.Execute()でPRのstatus:requires-changesラベルを削除する処理を追加
  - MockLabelManagerにGetPullRequestForIssueメソッドを追加
  - ReviseActionのテストケースを追加（PR存在、PR不在、エラー処理）
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス
- 関連PR: #292

ご確認のほどよろしくお願いいたします。