### PR TITLE
fix: テスト実行時の本番セッション誤削除防止機能 (#288)

### DIFF
--- a/.osoba.test.yml
+++ b/.osoba.test.yml
@@ -1,0 +1,48 @@
+# テスト環境用のosoba設定ファイル
+# このファイルはテスト実行時に使用され、本番環境との分離を確保します
+
+# GitHub関連の設定
+github:
+  # Issue/PRの監視間隔（テスト時は短めに設定）
+  poll_interval: 5s
+  pr_poll_interval: 5s
+  
+  # ラベル設定（本番と同じ）
+  labels:
+    plan: "status:needs-plan"
+    ready: "status:ready"
+    review: "status:review-requested"
+    requires_changes: "status:requires-changes"
+    revising: "status:revising"
+  
+  # 自動機能の設定（テスト時は無効化）
+  auto_merge_lgtm: false
+  auto_plan_issue: false
+  auto_revise_pr: false
+
+# tmux関連の設定
+tmux:
+  # テスト用のセッションプレフィックス
+  # 本番の "osoba-" と区別するため "test-osoba-" を使用
+  session_prefix: "test-osoba-"
+
+# ログ設定
+log:
+  level: "debug"  # テスト時は詳細なログを出力
+  format: "text"
+
+# Claude関連の設定
+claude:
+  phases:
+    plan:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:plan {{issue-number}}"
+    implement:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:implement {{issue-number}}"
+    review:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:review {{issue-number}}"
+    revise:
+      args: ["--dangerously-skip-permissions"]
+      prompt: "/osoba:revise {{issue-number}}"

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -48,7 +48,12 @@ func TestOpenCommand(t *testing.T) {
 				checkTmuxInstalledFunc = func() error { return nil }
 				getRepositoryNameFunc = func() (string, error) { return "test-repo", nil }
 				sessionExistsFunc = func(name string) (bool, error) {
-					if name == "osoba-test-repo" {
+					// テストモードに応じたプレフィックスをチェック
+					prefix := "osoba-"
+					if os.Getenv("OSOBA_TEST_MODE") == "true" {
+						prefix = "test-osoba-"
+					}
+					if name == prefix+"test-repo" {
 						return true, nil
 					}
 					return false, nil
@@ -62,7 +67,12 @@ func TestOpenCommand(t *testing.T) {
 				checkTmuxInstalledFunc = func() error { return nil }
 				getRepositoryNameFunc = func() (string, error) { return "test-repo", nil }
 				sessionExistsFunc = func(name string) (bool, error) {
-					if name == "osoba-test-repo" {
+					// テストモードに応じたプレフィックスをチェック
+					prefix := "osoba-"
+					if os.Getenv("OSOBA_TEST_MODE") == "true" {
+						prefix = "test-osoba-"
+					}
+					if name == prefix+"test-repo" {
 						return true, nil
 					}
 					return false, nil
@@ -108,7 +118,7 @@ func TestOpenCommand(t *testing.T) {
 					return false, nil
 				}
 			},
-			expectedError: "セッション 'osoba-test-repo' が見つかりません。先に 'osoba start'を実行してください",
+			expectedError: "", // 動的に設定するため空にする
 		},
 		{
 			name: "エラー: セッション確認でエラー",
@@ -143,7 +153,19 @@ func TestOpenCommand(t *testing.T) {
 			err := cmd.Execute()
 
 			// エラーの検証
-			if tt.expectedError != "" {
+			if tt.name == "エラー: セッションが存在しない" {
+				// テストモードに応じた期待値を動的に設定
+				prefix := "osoba-"
+				if os.Getenv("OSOBA_TEST_MODE") == "true" {
+					prefix = "test-osoba-"
+				}
+				expectedErr := fmt.Sprintf("セッション '%stest-repo' が見つかりません。先に 'osoba start'を実行してください", prefix)
+				if err == nil {
+					t.Errorf("期待されたエラーが発生しませんでした: %s", expectedErr)
+				} else if err.Error() != expectedErr {
+					t.Errorf("エラーメッセージが一致しません\n期待: %s\n実際: %s", expectedErr, err.Error())
+				}
+			} else if tt.expectedError != "" {
 				if err == nil {
 					t.Errorf("期待されたエラーが発生しませんでした: %s", tt.expectedError)
 				} else if err.Error() != tt.expectedError {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -347,6 +347,7 @@ tmux:
 			// 環境変数をクリア
 			originalGitHubToken := os.Getenv("GITHUB_TOKEN")
 			originalOsobaGitHubToken := os.Getenv("OSOBA_GITHUB_TOKEN")
+			originalTestMode := os.Getenv("OSOBA_TEST_MODE")
 			defer func() {
 				if originalGitHubToken != "" {
 					os.Setenv("GITHUB_TOKEN", originalGitHubToken)
@@ -358,9 +359,15 @@ tmux:
 				} else {
 					os.Unsetenv("OSOBA_GITHUB_TOKEN")
 				}
+				if originalTestMode != "" {
+					os.Setenv("OSOBA_TEST_MODE", originalTestMode)
+				} else {
+					os.Unsetenv("OSOBA_TEST_MODE")
+				}
 			}()
 			os.Unsetenv("GITHUB_TOKEN")
 			os.Unsetenv("OSOBA_GITHUB_TOKEN")
+			os.Unsetenv("OSOBA_TEST_MODE") // テスト設定ファイルの検証のため一時的にクリア
 
 			// viperをリセット
 			viper.Reset()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,15 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	t.Run("正常系: デフォルト設定でConfigを作成できる", func(t *testing.T) {
+		// 環境変数を一時的にクリア
+		origTestMode := os.Getenv("OSOBA_TEST_MODE")
+		os.Unsetenv("OSOBA_TEST_MODE")
+		defer func() {
+			if origTestMode != "" {
+				os.Setenv("OSOBA_TEST_MODE", origTestMode)
+			}
+		}()
+
 		cfg := NewConfig()
 		if cfg == nil {
 			t.Fatal("NewConfig() returned nil")
@@ -564,6 +573,15 @@ github:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// 環境変数を一時的にクリア（テストモードが影響しないように）
+			origTestMode := os.Getenv("OSOBA_TEST_MODE")
+			os.Unsetenv("OSOBA_TEST_MODE")
+			defer func() {
+				if origTestMode != "" {
+					os.Setenv("OSOBA_TEST_MODE", origTestMode)
+				}
+			}()
+
 			// テスト用設定ファイルを作成
 			filename := "test_config_reflection_" + tt.name + ".yml"
 			err := os.WriteFile(filename, []byte(tt.configContent), 0644)

--- a/internal/config/test_mode_test.go
+++ b/internal/config/test_mode_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestNewConfig_TestMode tests NewConfig behavior with OSOBA_TEST_MODE
+func TestNewConfig_TestMode(t *testing.T) {
+	tests := []struct {
+		name              string
+		testModeEnv       string
+		wantSessionPrefix string
+		wantIsTestMode    bool
+	}{
+		{
+			name:              "test mode enabled",
+			testModeEnv:       "true",
+			wantSessionPrefix: "test-osoba-",
+			wantIsTestMode:    true,
+		},
+		{
+			name:              "test mode disabled",
+			testModeEnv:       "",
+			wantSessionPrefix: "osoba-",
+			wantIsTestMode:    false,
+		},
+		{
+			name:              "test mode explicitly false",
+			testModeEnv:       "false",
+			wantSessionPrefix: "osoba-",
+			wantIsTestMode:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			origTestMode := os.Getenv("OSOBA_TEST_MODE")
+			if tt.testModeEnv != "" {
+				os.Setenv("OSOBA_TEST_MODE", tt.testModeEnv)
+			} else {
+				os.Unsetenv("OSOBA_TEST_MODE")
+			}
+			defer func() {
+				if origTestMode != "" {
+					os.Setenv("OSOBA_TEST_MODE", origTestMode)
+				} else {
+					os.Unsetenv("OSOBA_TEST_MODE")
+				}
+			}()
+
+			// Create config
+			cfg := NewConfig()
+
+			// Check session prefix
+			if cfg.Tmux.SessionPrefix != tt.wantSessionPrefix {
+				t.Errorf("SessionPrefix = %q, want %q", cfg.Tmux.SessionPrefix, tt.wantSessionPrefix)
+			}
+
+			// Check IsTestMode flag
+			if cfg.IsTestMode != tt.wantIsTestMode {
+				t.Errorf("IsTestMode = %v, want %v", cfg.IsTestMode, tt.wantIsTestMode)
+			}
+		})
+	}
+}
+
+// TestConfig_Load_TestMode tests that OSOBA_TEST_MODE overrides loaded config
+func TestConfig_Load_TestMode(t *testing.T) {
+	// Create test config file
+	configContent := `
+tmux:
+  session_prefix: "custom-osoba-"
+`
+	filename := "test_config_test_mode.yml"
+	err := os.WriteFile(filename, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+	defer os.Remove(filename)
+
+	tests := []struct {
+		name              string
+		testModeEnv       string
+		wantSessionPrefix string
+		wantIsTestMode    bool
+	}{
+		{
+			name:              "test mode overrides config file",
+			testModeEnv:       "true",
+			wantSessionPrefix: "test-osoba-",
+			wantIsTestMode:    true,
+		},
+		{
+			name:              "normal mode uses config file",
+			testModeEnv:       "",
+			wantSessionPrefix: "custom-osoba-",
+			wantIsTestMode:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			origTestMode := os.Getenv("OSOBA_TEST_MODE")
+			if tt.testModeEnv != "" {
+				os.Setenv("OSOBA_TEST_MODE", tt.testModeEnv)
+			} else {
+				os.Unsetenv("OSOBA_TEST_MODE")
+			}
+			defer func() {
+				if origTestMode != "" {
+					os.Setenv("OSOBA_TEST_MODE", origTestMode)
+				} else {
+					os.Unsetenv("OSOBA_TEST_MODE")
+				}
+			}()
+
+			// Create and load config
+			cfg := NewConfig()
+			if err := cfg.Load(filename); err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+
+			// Check session prefix
+			if cfg.Tmux.SessionPrefix != tt.wantSessionPrefix {
+				t.Errorf("SessionPrefix = %q, want %q", cfg.Tmux.SessionPrefix, tt.wantSessionPrefix)
+			}
+
+			// Check IsTestMode flag
+			if cfg.IsTestMode != tt.wantIsTestMode {
+				t.Errorf("IsTestMode = %v, want %v", cfg.IsTestMode, tt.wantIsTestMode)
+			}
+		})
+	}
+}
+
+// TestConfig_LoadOrDefault_TestMode tests LoadOrDefault with OSOBA_TEST_MODE
+func TestConfig_LoadOrDefault_TestMode(t *testing.T) {
+	tests := []struct {
+		name              string
+		testModeEnv       string
+		wantSessionPrefix string
+		wantIsTestMode    bool
+	}{
+		{
+			name:              "test mode with LoadOrDefault",
+			testModeEnv:       "true",
+			wantSessionPrefix: "test-osoba-",
+			wantIsTestMode:    true,
+		},
+		{
+			name:              "normal mode with LoadOrDefault",
+			testModeEnv:       "",
+			wantSessionPrefix: "osoba-",
+			wantIsTestMode:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			origTestMode := os.Getenv("OSOBA_TEST_MODE")
+			if tt.testModeEnv != "" {
+				os.Setenv("OSOBA_TEST_MODE", tt.testModeEnv)
+			} else {
+				os.Unsetenv("OSOBA_TEST_MODE")
+			}
+			defer func() {
+				if origTestMode != "" {
+					os.Setenv("OSOBA_TEST_MODE", origTestMode)
+				} else {
+					os.Unsetenv("OSOBA_TEST_MODE")
+				}
+			}()
+
+			// Create config and load with non-existent file
+			cfg := NewConfig()
+			cfg.LoadOrDefault("non-existent-file.yml")
+
+			// Check session prefix
+			if cfg.Tmux.SessionPrefix != tt.wantSessionPrefix {
+				t.Errorf("SessionPrefix = %q, want %q", cfg.Tmux.SessionPrefix, tt.wantSessionPrefix)
+			}
+
+			// Check IsTestMode flag
+			if cfg.IsTestMode != tt.wantIsTestMode {
+				t.Errorf("IsTestMode = %v, want %v", cfg.IsTestMode, tt.wantIsTestMode)
+			}
+		})
+	}
+}

--- a/internal/tmux/manager_real_integration_test.go
+++ b/internal/tmux/manager_real_integration_test.go
@@ -28,8 +28,13 @@ func TestTmuxManagerRealIntegration(t *testing.T) {
 		}
 	}
 
-	// テスト用のセッション名
-	testSessionName := "osoba-test-session-" + time.Now().Format("20060102-150405")
+	// 安全性チェック：本番セッションの存在確認
+	if err := SafetyCheckBeforeTests(); err != nil {
+		t.Logf("Safety check warning: %v", err)
+	}
+
+	// テスト用のセッション名（test-osoba-プレフィックスを使用）
+	testSessionName := "test-osoba-session-" + time.Now().Format("20060102-150405")
 
 	// クリーンアップ関数
 	cleanup := func() {
@@ -81,7 +86,7 @@ func TestTmuxManagerRealIntegration(t *testing.T) {
 		})
 
 		t.Run("セッション一覧取得", func(t *testing.T) {
-			sessions, err := manager.ListSessions("osoba")
+			sessions, err := manager.ListSessions("test-osoba")
 			assert.NoError(t, err)
 			assert.NotNil(t, sessions)
 
@@ -124,6 +129,11 @@ func TestTmuxManagerErrorHandling(t *testing.T) {
 		}
 	}
 
+	// 安全性チェック：本番セッションの存在確認
+	if err := SafetyCheckBeforeTests(); err != nil {
+		t.Logf("Safety check warning: %v", err)
+	}
+
 	manager := NewDefaultManager()
 
 	t.Run("存在しないセッションでのエラーハンドリング", func(t *testing.T) {
@@ -136,7 +146,7 @@ func TestTmuxManagerErrorHandling(t *testing.T) {
 	})
 
 	t.Run("重複セッション作成でのエラーハンドリング", func(t *testing.T) {
-		testSessionName := "osoba-duplicate-test-" + time.Now().Format("20060102-150405")
+		testSessionName := "test-osoba-duplicate-" + time.Now().Format("20060102-150405")
 
 		// クリーンアップ
 		defer func() {
@@ -169,6 +179,11 @@ func TestTmuxManagerConcurrentAccess(t *testing.T) {
 		}
 	}
 
+	// 安全性チェック：本番セッションの存在確認
+	if err := SafetyCheckBeforeTests(); err != nil {
+		t.Logf("Safety check warning: %v", err)
+	}
+
 	manager := NewDefaultManager()
 
 	t.Run("複数セッションの同時作成", func(t *testing.T) {
@@ -187,7 +202,7 @@ func TestTmuxManagerConcurrentAccess(t *testing.T) {
 
 		// 複数のgoroutineでセッションを作成
 		for i := 0; i < numSessions; i++ {
-			sessionNames[i] = "osoba-concurrent-test-" + time.Now().Format("20060102-150405") + "-" + string(rune('a'+i))
+			sessionNames[i] = "test-osoba-concurrent-" + time.Now().Format("20060102-150405") + "-" + string(rune('a'+i))
 
 			go func(sessionName string) {
 				err := manager.CreateSession(sessionName)
@@ -210,7 +225,7 @@ func TestTmuxManagerConcurrentAccess(t *testing.T) {
 		assert.Equal(t, numSessions, successCount, "All concurrent session creations should succeed")
 
 		// セッションが実際に作成されたことを確認
-		sessions, err := manager.ListSessions("osoba")
+		sessions, err := manager.ListSessions("test-osoba")
 		assert.NoError(t, err)
 
 		for _, sessionName := range sessionNames {
@@ -241,10 +256,15 @@ func TestTmuxManagerPerformance(t *testing.T) {
 		}
 	}
 
+	// 安全性チェック：本番セッションの存在確認
+	if err := SafetyCheckBeforeTests(); err != nil {
+		t.Logf("Safety check warning: %v", err)
+	}
+
 	manager := NewDefaultManager()
 
 	t.Run("セッション作成のレスポンス時間", func(t *testing.T) {
-		testSessionName := "osoba-perf-test-" + time.Now().Format("20060102-150405")
+		testSessionName := "test-osoba-perf-" + time.Now().Format("20060102-150405")
 
 		defer func() {
 			exec.Command("tmux", "kill-session", "-t", testSessionName).Run()
@@ -262,7 +282,7 @@ func TestTmuxManagerPerformance(t *testing.T) {
 
 	t.Run("セッション一覧取得のレスポンス時間", func(t *testing.T) {
 		start := time.Now()
-		sessions, err := manager.ListSessions("osoba")
+		sessions, err := manager.ListSessions("test-osoba")
 		duration := time.Since(start)
 
 		assert.NoError(t, err)

--- a/internal/tmux/safety_check.go
+++ b/internal/tmux/safety_check.go
@@ -1,0 +1,117 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GetSessionPrefix returns the appropriate session prefix based on environment
+func GetSessionPrefix() string {
+	if os.Getenv("OSOBA_TEST_MODE") == "true" {
+		return "test-osoba-"
+	}
+	return "osoba-"
+}
+
+// IsCIEnvironment detects if running in CI environment
+func IsCIEnvironment() bool {
+	// Check common CI environment variables
+	ciVars := []string{"CI", "GITHUB_ACTIONS", "JENKINS", "TRAVIS", "CIRCLECI"}
+	for _, envVar := range ciVars {
+		if os.Getenv(envVar) == "true" || os.Getenv(envVar) == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckProductionSessions lists existing production sessions
+func CheckProductionSessions() ([]string, error) {
+	output, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			// No sessions exist
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	sessions := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var prodSessions []string
+
+	for _, session := range sessions {
+		if session != "" && strings.HasPrefix(session, "osoba-") &&
+			!strings.HasPrefix(session, "test-osoba-") {
+			prodSessions = append(prodSessions, session)
+		}
+	}
+
+	return prodSessions, nil
+}
+
+// SafetyCheckBeforeTests performs safety checks before running tests
+func SafetyCheckBeforeTests() error {
+	// Skip check if not in test mode
+	if os.Getenv("OSOBA_TEST_MODE") != "true" {
+		return nil
+	}
+
+	// Check for production sessions
+	prodSessions, err := CheckProductionSessions()
+	if err != nil {
+		return fmt.Errorf("failed to check production sessions: %w", err)
+	}
+
+	if len(prodSessions) > 0 {
+		fmt.Fprintf(os.Stderr, "⚠️  WARNING: Found %d production osoba session(s):\n", len(prodSessions))
+		for _, session := range prodSessions {
+			fmt.Fprintf(os.Stderr, "   - %s\n", session)
+		}
+
+		// In CI environment, just warn
+		if IsCIEnvironment() {
+			fmt.Fprintf(os.Stderr, "   Running in CI environment, continuing with tests...\n")
+		} else {
+			// In local environment, warn but continue
+			fmt.Fprintf(os.Stderr, "   Tests will use 'test-osoba-' prefix to avoid conflicts.\n")
+			fmt.Fprintf(os.Stderr, "   Production sessions should be safe.\n")
+		}
+	}
+
+	return nil
+}
+
+// IsTestSession checks if a session name is a test session
+func IsTestSession(sessionName string) bool {
+	return strings.HasPrefix(sessionName, "test-osoba-")
+}
+
+// IsProductionSession checks if a session name is a production session
+func IsProductionSession(sessionName string) bool {
+	return strings.HasPrefix(sessionName, "osoba-") && !IsTestSession(sessionName)
+}
+
+// CleanupTestSessions removes all test sessions
+func CleanupTestSessions() error {
+	output, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			// No sessions exist
+			return nil
+		}
+		return err
+	}
+
+	sessions := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+	for _, session := range sessions {
+		if session != "" && IsTestSession(session) {
+			// Kill test session, ignore errors if session doesn't exist
+			exec.Command("tmux", "kill-session", "-t", session).Run()
+		}
+	}
+
+	return nil
+}

--- a/internal/tmux/safety_check_test.go
+++ b/internal/tmux/safety_check_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+// +build integration
+
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSafetyCheckForProductionSessions tests the safety check functionality
+func TestSafetyCheckForProductionSessions(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingSessions  []string
+		testSessionPrefix string
+		prodSessionPrefix string
+		expectWarning     bool
+		expectBlocked     bool
+	}{
+		{
+			name:              "no production sessions",
+			existingSessions:  []string{},
+			testSessionPrefix: "test-osoba-",
+			prodSessionPrefix: "osoba-",
+			expectWarning:     false,
+			expectBlocked:     false,
+		},
+		{
+			name:              "production sessions exist",
+			existingSessions:  []string{"osoba-repo1", "osoba-repo2"},
+			testSessionPrefix: "test-osoba-",
+			prodSessionPrefix: "osoba-",
+			expectWarning:     true,
+			expectBlocked:     false, // In CI mode, only warn
+		},
+		{
+			name:              "only test sessions exist",
+			existingSessions:  []string{"test-osoba-123", "test-osoba-456"},
+			testSessionPrefix: "test-osoba-",
+			prodSessionPrefix: "osoba-",
+			expectWarning:     false,
+			expectBlocked:     false,
+		},
+		{
+			name:              "mixed sessions exist",
+			existingSessions:  []string{"osoba-prod", "test-osoba-123"},
+			testSessionPrefix: "test-osoba-",
+			prodSessionPrefix: "osoba-",
+			expectWarning:     true,
+			expectBlocked:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the session listing
+			sessions := tt.existingSessions
+
+			// Check for production sessions
+			hasProductionSessions := false
+			for _, session := range sessions {
+				if strings.HasPrefix(session, tt.prodSessionPrefix) &&
+					!strings.HasPrefix(session, tt.testSessionPrefix) {
+					hasProductionSessions = true
+					break
+				}
+			}
+
+			assert.Equal(t, tt.expectWarning, hasProductionSessions,
+				"Production session detection mismatch")
+		})
+	}
+}
+
+// TestSessionPrefixConfiguration tests that session prefixes are properly configured
+func TestSessionPrefixConfiguration(t *testing.T) {
+	tests := []struct {
+		name           string
+		envVar         string
+		expectedPrefix string
+	}{
+		{
+			name:           "test mode enabled",
+			envVar:         "true",
+			expectedPrefix: "test-osoba-",
+		},
+		{
+			name:           "test mode disabled",
+			envVar:         "",
+			expectedPrefix: "osoba-",
+		},
+		{
+			name:           "test mode explicitly false",
+			envVar:         "false",
+			expectedPrefix: "osoba-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			if tt.envVar != "" {
+				os.Setenv("OSOBA_TEST_MODE", tt.envVar)
+				defer os.Unsetenv("OSOBA_TEST_MODE")
+			}
+
+			// Get the session prefix based on environment
+			prefix := GetSessionPrefix()
+			assert.Equal(t, tt.expectedPrefix, prefix)
+		})
+	}
+}
+
+// TestCIEnvironmentDetection tests CI environment detection
+func TestCIEnvironmentDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		expectCI bool
+	}{
+		{
+			name:     "CI environment",
+			envVars:  map[string]string{"CI": "true"},
+			expectCI: true,
+		},
+		{
+			name:     "GitHub Actions environment",
+			envVars:  map[string]string{"GITHUB_ACTIONS": "true"},
+			expectCI: true,
+		},
+		{
+			name:     "local environment",
+			envVars:  map[string]string{},
+			expectCI: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			for key, val := range tt.envVars {
+				os.Setenv(key, val)
+				defer os.Unsetenv(key)
+			}
+
+			// Check CI detection
+			isCI := IsCIEnvironment()
+			assert.Equal(t, tt.expectCI, isCI)
+		})
+	}
+}
+
+// TestCheckProductionSessions checks if production sessions are properly detected
+func TestCheckProductionSessions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Check if tmux is available
+	if err := exec.Command("tmux", "list-sessions").Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			// No sessions, which is fine
+		} else {
+			t.Skip("tmux command not available")
+		}
+	}
+
+	// Get actual sessions
+	prodSessions, err := CheckProductionSessions()
+	require.NoError(t, err)
+
+	// Log found sessions for debugging
+	if len(prodSessions) > 0 {
+		t.Logf("Found %d production sessions: %v", len(prodSessions), prodSessions)
+	}
+
+	// In test mode, we should not have production sessions with our test prefix
+	testPrefix := GetSessionPrefix()
+	if testPrefix == "test-osoba-" {
+		for _, session := range prodSessions {
+			assert.False(t, strings.HasPrefix(session, "test-osoba-"),
+				"Test session should not be detected as production: %s", session)
+		}
+	}
+}


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #288
- 対応内容:
  - テスト用セッション名を`test-osoba-`プレフィックスに変更し、本番との分離を実現
  - 環境変数`OSOBA_TEST_MODE`によるテストモード識別機能を実装
  - 統合テスト実行前の安全性チェック機能を追加（本番セッション検出と警告表示）
  - テスト用設定ファイル`.osoba.test.yml`を作成
  - テスト実行ガイドラインをドキュメントに追加
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 統合テスト: ✅ パス
  - フルテスト: ✅ パス

## 主な変更点

### 1. セッション命名規則の変更
- `internal/tmux/manager_real_integration_test.go`：全テストセッション名を`test-osoba-`プレフィックスに変更
- テストと本番のセッションが明確に区別されるようになりました

### 2. 環境変数によるテストモード制御
- `internal/config/config.go`：`OSOBA_TEST_MODE`環境変数のサポートを追加
- テストモード時は自動的に`test-osoba-`プレフィックスが使用されます

### 3. 安全性チェック機能
- `internal/tmux/safety_check.go`：新規作成
  - 本番セッション検出機能
  - CI環境判定機能
  - テストセッションのクリーンアップ機能
- 統合テスト実行前に自動的に本番セッションの存在を確認し、警告を表示

### 4. ドキュメントの更新
- `docs/development/testing-guide.md`：テスト実行時の安全性確保に関するセクションを追加

## テスト結果

```bash
# 通常のテスト（環境変数なし）
$ go test ./...
ok  	github.com/douhashi/osoba/internal/config	0.018s
ok  	github.com/douhashi/osoba/internal/tmux	0.010s

# 統合テスト（テストモード有効）
$ OSOBA_TEST_MODE=true go test ./internal/tmux -tags=integration -v
⚠️  WARNING: Found 2 production osoba session(s):
   - osoba-osoba
   - osoba-test
   Tests will use 'test-osoba-' prefix to avoid conflicts.
--- PASS: TestTmuxManagerRealIntegration (0.07s)
```

## 確認事項

- [x] 本番セッション（`osoba-`プレフィックス）が保護されることを確認
- [x] テストセッション（`test-osoba-`プレフィックス）が正しく作成・削除されることを確認
- [x] CI環境での動作を想定した環境変数制御が機能することを確認
- [x] 既存のテストが正常に動作することを確認

ご確認のほどよろしくお願いいたします。