### PR TITLE
fix: DevContainerのrebuildスクリプトを修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,17 +31,16 @@ RUN type -p curl >/dev/null || (apt-get update && apt-get install curl -y) && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Go development tools
-ARG GO_TOOLS_VERSION="latest"
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GO_TOOLS_VERSION} && \
-    go install github.com/goreleaser/goreleaser/v2@${GO_TOOLS_VERSION} && \
-    go install github.com/golang/mock/mockgen@${GO_TOOLS_VERSION} && \
-    go install golang.org/x/tools/cmd/goimports@${GO_TOOLS_VERSION} && \
-    go install github.com/go-delve/delve/cmd/dlv@${GO_TOOLS_VERSION} && \
-    go install golang.org/x/tools/gopls@${GO_TOOLS_VERSION} && \
-    go install github.com/fatih/gomodifytags@${GO_TOOLS_VERSION} && \
-    go install github.com/josharian/impl@${GO_TOOLS_VERSION} && \
-    go install github.com/haya14busa/goplay/cmd/goplay@${GO_TOOLS_VERSION} && \
-    go install github.com/cweill/gotests/gotests@${GO_TOOLS_VERSION}
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2 && \
+    go install github.com/goreleaser/goreleaser@v1.26.2 && \
+    go install github.com/golang/mock/mockgen@v1.6.0 && \
+    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@v1.21.0 && \
+    go install golang.org/x/tools/gopls@v0.13.2 && \
+    go install github.com/fatih/gomodifytags@v1.16.0 && \
+    go install github.com/josharian/impl@v1.1.0 && \
+    go install github.com/haya14busa/goplay/cmd/goplay@v1.0.0 && \
+    go install github.com/cweill/gotests/gotests@v1.6.0
 
 # Clean go cache to reduce image size
 RUN go clean -cache -modcache

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -109,7 +109,7 @@
   },
   "forwardPorts": [],
   "postCreateCommand": "/bin/bash .devcontainer/postCreateCommand.sh",
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": "git config --add safe.directory ${containerWorkspaceFolder} 2>/dev/null || true",
   "postAttachCommand": "echo 'Welcome to osoba Development Container! Run \"make help\" to see available commands.'",
   "remoteUser": "vscode",
   "containerEnv": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -27,8 +27,8 @@ fi
 
 # Setup git configuration for better DevContainer experience
 echo "⚙️ Configuring git..."
-git config --global init.defaultBranch main
-git config --global pull.rebase false
+# Note: .gitconfig is mounted as read-only, so we skip global config
+# Users can configure these settings locally if needed
 
 # Create useful aliases
 echo "📝 Setting up shell aliases..."


### PR DESCRIPTION
## 概要
DevContainerのrebuildスクリプト（`.devcontainer/bin/rebuild`）が失敗する問題を修正しました。

## 問題
- GoReleaserとgoplsの最新版がGo 1.24以上を要求するため、Go 1.23環境でビルドが失敗
- postCreateCommand内のgit configが、read-onlyマウントされた.gitconfigへの書き込みを試みて失敗

## 変更内容
### 🔧 Dockerfileの修正
- **goreleaser**: `v2@latest` → `v1.26.2`（Go 1.24要求のため）
- **gopls**: `@latest` → `v0.13.2`（Go 1.24.2要求のため）
- その他のツールも安定版に固定し、ビルドの再現性を向上

### 📝 postCreateCommand.shの修正
- git config --globalコマンドを削除（.gitconfigがread-onlyマウントのため）
- 代わりにコメントを追加して理由を明記

### ⚙️ devcontainer.jsonの修正
- postStartCommandでエラーを無視するように修正（`2>/dev/null || true`を追加）

## テスト結果
- [x] `.devcontainer/bin/rebuild`が正常に完了
- [x] コンテナが正常に起動
- [x] 開発環境のセットアップが完了

## 関連Issue
なし

🤖 Generated with [Claude Code](https://claude.ai/code)