### PR TITLE
fix: ReviseAction実行時のstatus:reviewingラベル削除処理を追加 (#326)

### DIFF
--- a/internal/watcher/actions/revise_action.go
+++ b/internal/watcher/actions/revise_action.go
@@ -144,6 +144,14 @@ func (a *ReviseAction) Execute(ctx context.Context, issue *github.Issue) error {
 				"error", err,
 			)
 		}
+		// status:reviewingラベルも削除（存在しない場合やエラーでも処理継続）
+		if err := a.labelManager.RemoveLabel(ctx, int(issueNumber), "status:reviewing"); err != nil {
+			a.logger.Error("Failed to remove label",
+				"issue_number", issueNumber,
+				"label", "status:reviewing",
+				"error", err,
+			)
+		}
 		if err := a.labelManager.AddLabel(ctx, int(issueNumber), "status:revising"); err != nil {
 			a.logger.Error("Failed to add label",
 				"issue_number", issueNumber,


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #326
- 対応内容:
  - ReviseAction実行時に`status:reviewing`ラベルを自動削除する機能を追加
  - `status:requires-changes`削除後に`status:reviewing`も削除するように修正
  - ラベル削除失敗時はエラーログ出力のみで処理継続
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス 
  - 結合テスト: ✅ パス 
  - フルテスト: ✅ パス 
- 関連PR: このPR

## 変更内容

### 実装ファイル
- `internal/watcher/actions/revise_action.go`: `status:reviewing`ラベル削除処理を追加（147-154行目）

### テストファイル  
- `internal/watcher/actions/revise_action_test.go`: 
  - 既存テストケースに`status:reviewing`ラベル削除の検証を追加
  - 新規テストケース「status:reviewingラベル削除失敗でも処理継続」を追加

## テスト結果

```
=== RUN   TestReviseAction_Execute
--- PASS: TestReviseAction_Execute (0.00s)
    --- PASS: TestReviseAction_Execute/正常なReviseアクション実行（PR存在） (0.00s)
    --- PASS: TestReviseAction_Execute/正常なReviseアクション実行（PR存在しない） (0.00s)
    --- PASS: TestReviseAction_Execute/PRラベル削除失敗でも処理継続 (0.00s)
    --- PASS: TestReviseAction_Execute/status:reviewingラベル削除失敗でも処理継続 (0.00s)
```

ご確認のほどよろしくお願いいたします。