### PR TITLE
feat: CreatePane関数へのペイン数制限機能の統合 (#347)

### DIFF
--- a/internal/tmux/manager_pane_test.go
+++ b/internal/tmux/manager_pane_test.go
@@ -1,0 +1,339 @@
+package tmux
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatePane_WithPaneLimit(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          *PaneConfig
+		existingPanes   string
+		setupMock       func(*MockCommandExecutor)
+		expectedError   bool
+		expectedPaneIdx int
+	}{
+		{
+			name: "制限有効・上限未満",
+			config: &PaneConfig{
+				LimitPanesEnabled: true,
+				MaxPanesPerWindow: 3,
+			},
+			existingPanes: "0:Plan:1:80:24\n1:Implementation:0:80:24",
+			setupMock: func(m *MockCommandExecutor) {
+				// ListPanes (制限チェック用)
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:1:80:24\n1:Implementation:0:80:24", nil).Once()
+
+				// CreatePane
+				m.On("Execute", "tmux", []string{"split-window", "-h", "-p", "50", "-t", "test-session:test-window"}).
+					Return("", nil).Once()
+
+				// ListPanes (作成後)
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:0:80:24\n1:Implementation:0:80:24\n2::1:80:24", nil).Once()
+
+				// SetPaneTitle
+				m.On("Execute", "tmux", []string{"set-option", "-t", "test-session:test-window.2", "-p",
+					"pane-border-format", " Review "}).
+					Return("", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:0:80:24\n1:Implementation:0:80:24\n2:Review:1:80:24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - GetWindowSize
+				m.On("Execute", "tmux", []string{"display-message", "-p", "-t", "test-session:test-window",
+					"#{window_width} #{window_height}"}).
+					Return("240 24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - select-layout
+				m.On("Execute", "tmux", []string{"select-layout", "-t", "test-session:test-window", "even-horizontal"}).
+					Return("", nil).Once()
+			},
+			expectedError:   false,
+			expectedPaneIdx: 2,
+		},
+		{
+			name: "制限有効・上限到達・非アクティブペイン削除",
+			config: &PaneConfig{
+				LimitPanesEnabled: true,
+				MaxPanesPerWindow: 3,
+			},
+			existingPanes: "0:Plan:0:80:24\n1:Implementation:0:80:24\n2:Review:1:80:24",
+			setupMock: func(m *MockCommandExecutor) {
+				// ListPanes (制限チェック用)
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:0:80:24\n1:Implementation:0:80:24\n2:Review:1:80:24", nil).Once()
+
+				// KillPane (最古の非アクティブペイン削除)
+				m.On("Execute", "tmux", []string{"kill-pane", "-t", "test-session:test-window.0"}).
+					Return("", nil).Once()
+
+				// ResizePanesEvenlyWithRetry after kill - ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Implementation:0:120:24\n1:Review:1:120:24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry after kill - GetWindowSize
+				m.On("Execute", "tmux", []string{"display-message", "-p", "-t", "test-session:test-window",
+					"#{window_width} #{window_height}"}).
+					Return("240 24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry after kill - select-layout
+				m.On("Execute", "tmux", []string{"select-layout", "-t", "test-session:test-window", "even-horizontal"}).
+					Return("", nil).Once()
+
+				// CreatePane
+				m.On("Execute", "tmux", []string{"split-window", "-h", "-p", "50", "-t", "test-session:test-window"}).
+					Return("", nil).Once()
+
+				// ListPanes (作成後)
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Implementation:0:80:24\n1:Review:0:80:24\n2::1:80:24", nil).Once()
+
+				// SetPaneTitle
+				m.On("Execute", "tmux", []string{"set-option", "-t", "test-session:test-window.2", "-p",
+					"pane-border-format", " Debug "}).
+					Return("", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Implementation:0:80:24\n1:Review:0:80:24\n2:Debug:1:80:24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - GetWindowSize
+				m.On("Execute", "tmux", []string{"display-message", "-p", "-t", "test-session:test-window",
+					"#{window_width} #{window_height}"}).
+					Return("240 24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - select-layout
+				m.On("Execute", "tmux", []string{"select-layout", "-t", "test-session:test-window", "even-horizontal"}).
+					Return("", nil).Once()
+			},
+			expectedError:   false,
+			expectedPaneIdx: 2,
+		},
+		{
+			name:   "制限無効",
+			config: nil,
+			setupMock: func(m *MockCommandExecutor) {
+				// CreatePane
+				m.On("Execute", "tmux", []string{"split-window", "-h", "-p", "50", "-t", "test-session:test-window"}).
+					Return("", nil).Once()
+
+				// ListPanes (作成後)
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:0:80:24\n1::1:80:24", nil).Once()
+
+				// SetPaneTitle
+				m.On("Execute", "tmux", []string{"set-option", "-t", "test-session:test-window.1", "-p",
+					"pane-border-format", " Implementation "}).
+					Return("", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:0:120:24\n1:Implementation:1:120:24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - GetWindowSize
+				m.On("Execute", "tmux", []string{"display-message", "-p", "-t", "test-session:test-window",
+					"#{window_width} #{window_height}"}).
+					Return("240 24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - select-layout
+				m.On("Execute", "tmux", []string{"select-layout", "-t", "test-session:test-window", "even-horizontal"}).
+					Return("", nil).Once()
+			},
+			expectedError:   false,
+			expectedPaneIdx: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := new(MockCommandExecutor)
+			tt.setupMock(mockExec)
+			defer mockExec.AssertExpectations(t)
+
+			manager := NewDefaultManagerWithExecutor(mockExec)
+
+			opts := PaneOptions{
+				Split:      "-h",
+				Percentage: 50,
+				Config:     tt.config,
+			}
+
+			// タイトルを設定してテスト
+			titles := map[string]string{
+				"制限有効・上限未満":             "Review",
+				"制限有効・上限到達・非アクティブペイン削除": "Debug",
+				"制限無効": "Implementation",
+			}
+
+			if title, ok := titles[tt.name]; ok {
+				opts.Title = title
+				pane, err := manager.CreatePane("test-session", "test-window", opts)
+
+				if tt.expectedError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, pane)
+					assert.Equal(t, tt.expectedPaneIdx, pane.Index)
+					assert.Equal(t, title, pane.Title)
+				}
+			}
+		})
+	}
+}
+
+func TestEnforcePaneLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxPanes      int
+		existingPanes string
+		setupMock     func(*MockCommandExecutor)
+		expectedError bool
+	}{
+		{
+			name:          "上限未満",
+			maxPanes:      3,
+			existingPanes: "0:Plan:1:120:24\n1:Implementation:0:120:24",
+			setupMock: func(m *MockCommandExecutor) {
+				// ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:1:120:24\n1:Implementation:0:120:24", nil).Once()
+			},
+			expectedError: false,
+		},
+		{
+			name:          "上限到達・非アクティブペイン削除",
+			maxPanes:      2,
+			existingPanes: "0:Plan:0:120:24\n1:Implementation:1:120:24",
+			setupMock: func(m *MockCommandExecutor) {
+				// ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Plan:0:120:24\n1:Implementation:1:120:24", nil).Once()
+
+				// KillPane
+				m.On("Execute", "tmux", []string{"kill-pane", "-t", "test-session:test-window.0"}).
+					Return("", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:Implementation:1:240:24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - スキップ（ペイン1個のため）
+			},
+			expectedError: false,
+		},
+		{
+			name:          "デフォルト値使用",
+			maxPanes:      0,
+			existingPanes: "0:P1:0:60:24\n1:P2:0:60:24\n2:P3:1:60:24\n3:P4:0:60:24",
+			setupMock: func(m *MockCommandExecutor) {
+				// ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:P1:0:60:24\n1:P2:0:60:24\n2:P3:1:60:24\n3:P4:0:60:24", nil).Once()
+
+				// KillPane (デフォルト値3なので、4個→3個に削減)
+				m.On("Execute", "tmux", []string{"kill-pane", "-t", "test-session:test-window.0"}).
+					Return("", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - ListPanes
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("0:P2:0:80:24\n1:P3:1:80:24\n2:P4:0:80:24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - GetWindowSize
+				m.On("Execute", "tmux", []string{"display-message", "-p", "-t", "test-session:test-window",
+					"#{window_width} #{window_height}"}).
+					Return("240 24", nil).Once()
+
+				// ResizePanesEvenlyWithRetry - select-layout
+				m.On("Execute", "tmux", []string{"select-layout", "-t", "test-session:test-window", "even-horizontal"}).
+					Return("", nil).Once()
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := new(MockCommandExecutor)
+			tt.setupMock(mockExec)
+			defer mockExec.AssertExpectations(t)
+
+			manager := NewDefaultManagerWithExecutor(mockExec)
+			err := manager.enforcePaneLimit("test-session", "test-window", tt.maxPanes)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreatePane_Error(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*MockCommandExecutor)
+		expectedError string
+	}{
+		{
+			name: "split-window失敗",
+			setupMock: func(m *MockCommandExecutor) {
+				m.On("Execute", "tmux", []string{"split-window", "-h", "-p", "50", "-t", "test-session:test-window"}).
+					Return("", fmt.Errorf("window not found")).Once()
+			},
+			expectedError: "failed to create pane: window not found",
+		},
+		{
+			name: "ListPanes失敗",
+			setupMock: func(m *MockCommandExecutor) {
+				m.On("Execute", "tmux", []string{"split-window", "-h", "-p", "50", "-t", "test-session:test-window"}).
+					Return("", nil).Once()
+				m.On("Execute", "tmux", []string{"list-panes", "-t", "test-session:test-window", "-F",
+					"#{pane_index}:#{pane_title}:#{pane_active}:#{pane_width}:#{pane_height}"}).
+					Return("", fmt.Errorf("session not found")).Once()
+			},
+			expectedError: "failed to list panes after creation: failed to list panes: session not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := new(MockCommandExecutor)
+			tt.setupMock(mockExec)
+			defer mockExec.AssertExpectations(t)
+
+			manager := NewDefaultManagerWithExecutor(mockExec)
+			opts := PaneOptions{
+				Split:      "-h",
+				Percentage: 50,
+			}
+
+			pane, err := manager.CreatePane("test-session", "test-window", opts)
+
+			assert.Error(t, err)
+			assert.Nil(t, pane)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}

--- a/internal/tmux/pane_manager.go
+++ b/internal/tmux/pane_manager.go
@@ -32,9 +32,16 @@ type PaneManager interface {
 
 // PaneOptions ペイン作成時のオプション
 type PaneOptions struct {
-	Split      string // "-v" (vertical) or "-h" (horizontal)
-	Percentage int    // split percentage
-	Title      string // pane title for border
+	Split      string      // "-v" (vertical) or "-h" (horizontal)
+	Percentage int         // split percentage
+	Title      string      // pane title for border
+	Config     *PaneConfig // ペイン管理設定（オプション）
+}
+
+// PaneConfig ペイン管理設定
+type PaneConfig struct {
+	LimitPanesEnabled bool // ペイン数制限を有効にするか
+	MaxPanesPerWindow int  // ウィンドウごとの最大ペイン数
 }
 
 // PaneInfo ペイン情報

--- a/internal/watcher/actions/base_executor_pane_limit_test.go
+++ b/internal/watcher/actions/base_executor_pane_limit_test.go
@@ -42,21 +42,15 @@ func TestBaseExecutor_EnsurePane_WithPaneLimit(t *testing.T) {
 				tmux.On("GetPaneByTitle", "test-session", "issue-999", "Review").
 					Return(nil, assert.AnError).Once()
 
-				// ペイン一覧取得（3つ存在、上限に達している）
-				tmux.On("ListPanes", "test-session", "issue-999").Return([]*tmuxpkg.PaneInfo{
-					{Index: 0, Title: "Plan", Active: false},
-					{Index: 1, Title: "Implementation", Active: true},
-					{Index: 2, Title: "Test", Active: false},
-				}, nil).Once()
-
-				// 最古の非アクティブペイン（index: 0）を削除
-				tmux.On("KillPane", "test-session", "issue-999", 0).Return(nil).Once()
-
-				// 新規pane作成
+				// 新規pane作成（ペイン数制限機能が統合されたCreatePaneが呼ばれる）
 				tmux.On("CreatePane", "test-session", "issue-999", tmuxpkg.PaneOptions{
 					Split:      "-h",
 					Percentage: 50,
 					Title:      "Review",
+					Config: &tmuxpkg.PaneConfig{
+						LimitPanesEnabled: true,
+						MaxPanesPerWindow: 3,
+					},
 				}).Return(&tmuxpkg.PaneInfo{Index: 3, Title: "Review", Active: true}, nil).Once()
 
 				// Worktreeパス取得
@@ -85,17 +79,15 @@ func TestBaseExecutor_EnsurePane_WithPaneLimit(t *testing.T) {
 				tmux.On("GetPaneByTitle", "test-session", "issue-999", "Review").
 					Return(nil, assert.AnError).Once()
 
-				// ペイン一覧取得（2つ存在、両方アクティブ）
-				tmux.On("ListPanes", "test-session", "issue-999").Return([]*tmuxpkg.PaneInfo{
-					{Index: 0, Title: "Plan", Active: true},
-					{Index: 1, Title: "Implementation", Active: true},
-				}, nil).Once()
-
-				// 削除はスキップされ、新規pane作成
+				// 新規pane作成（ペイン数制限機能が統合されたCreatePaneが呼ばれる）
 				tmux.On("CreatePane", "test-session", "issue-999", tmuxpkg.PaneOptions{
 					Split:      "-h",
 					Percentage: 50,
 					Title:      "Review",
+					Config: &tmuxpkg.PaneConfig{
+						LimitPanesEnabled: true,
+						MaxPanesPerWindow: 2,
+					},
 				}).Return(&tmuxpkg.PaneInfo{Index: 2, Title: "Review", Active: true}, nil).Once()
 
 				// Worktreeパス取得
@@ -126,11 +118,12 @@ func TestBaseExecutor_EnsurePane_WithPaneLimit(t *testing.T) {
 
 				// ListPanesは呼ばれない（制限無効のため）
 
-				// 新規pane作成
+				// 新規pane作成（制限無効なのでConfig=nil）
 				tmux.On("CreatePane", "test-session", "issue-999", tmuxpkg.PaneOptions{
 					Split:      "-h",
 					Percentage: 50,
 					Title:      "Review",
+					Config:     nil,
 				}).Return(&tmuxpkg.PaneInfo{Index: 3, Title: "Review", Active: true}, nil).Once()
 
 				// Worktreeパス取得
@@ -159,17 +152,15 @@ func TestBaseExecutor_EnsurePane_WithPaneLimit(t *testing.T) {
 				tmux.On("GetPaneByTitle", "test-session", "issue-999", "Implementation").
 					Return(nil, assert.AnError).Once()
 
-				// ペイン一覧取得（2つ存在、上限未満）
-				tmux.On("ListPanes", "test-session", "issue-999").Return([]*tmuxpkg.PaneInfo{
-					{Index: 0, Title: "Plan", Active: false},
-					{Index: 1, Title: "Test", Active: true},
-				}, nil).Once()
-
-				// 削除は実行されず、新規pane作成
+				// 新規pane作成（ペイン数制限機能が統合されたCreatePaneが呼ばれる）
 				tmux.On("CreatePane", "test-session", "issue-999", tmuxpkg.PaneOptions{
 					Split:      "-h",
 					Percentage: 50,
 					Title:      "Implementation",
+					Config: &tmuxpkg.PaneConfig{
+						LimitPanesEnabled: true,
+						MaxPanesPerWindow: 5,
+					},
 				}).Return(&tmuxpkg.PaneInfo{Index: 2, Title: "Implementation", Active: true}, nil).Once()
 
 				// Worktreeパス取得


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #347
- 対応内容:
  - PaneOptions構造体にPaneConfig設定フィールドを追加
  - CreatePane関数内でペイン数制限ロジックを統合
  - base_executor.goから重複コードを削除しCreatePaneの機能を利用するようリファクタリング
  - enforcePaneLimitプライベート関数の実装（最古の非アクティブペイン削除）
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス
  - 結合テスト: ✅ パス
  - フルテスト: ✅ パス

## 変更内容

### 1. PaneOptions構造体の拡張
- `internal/tmux/pane_manager.go`: PaneOptionsにPaneConfig構造体を追加
- 後方互換性を維持（ConfigがnilでもCreatePaneは正常動作）

### 2. CreatePane関数の機能強化
- `internal/tmux/manager_pane.go`: 
  - ペイン作成前の制限チェック機能を追加
  - enforcePaneLimitメソッドで上限超過時の自動削除を実装
  - ペイン削除後の自動レイアウト調整も統合

### 3. base_executor.goのリファクタリング
- `internal/watcher/actions/base_executor.go`:
  - ensurePaneメソッドから重複コードを削除
  - CreatePaneに設定を渡すように変更
  - コードの重複を排除しDRY原則を適用

### 4. テストの追加・更新
- `internal/tmux/manager_pane_test.go`: 新規作成
  - CreatePaneのペイン数制限機能テスト
  - enforcePaneLimitメソッドのテスト
  - エラーケースのテスト
- 既存テストの修正:
  - PaneOptions構造体変更に伴うテストの更新

## テスト結果
```
ok  	github.com/douhashi/osoba/internal/tmux	(cached)
ok  	github.com/douhashi/osoba/internal/watcher/actions	0.013s
```

全てのテストがパスしています。

ご確認のほどよろしくお願いいたします。