### PR TITLE
feat: クリーンアップ機能の設定管理を実装 (#349)

### DIFF
--- a/examples/config/sample-config.yml
+++ b/examples/config/sample-config.yml
@@ -108,6 +108,20 @@ notifications:
   #   from: "osoba@example.com"
   #   to: ["dev@example.com"]
 
+# クリーンアップ設定
+cleanup:
+  # クリーンアップ機能の有効化
+  enabled: true
+  
+  # クリーンアップ実行間隔（分）
+  # 最小: 1, 最大: 60
+  interval_minutes: 5
+  
+  # Issue Windowsクリーンアップ設定
+  issue_windows:
+    # tmuxウィンドウのクリーンアップを有効化
+    enabled: true
+
 # 高度な設定
 advanced:
   # 並行処理数

--- a/internal/config/cleanup_config_test.go
+++ b/internal/config/cleanup_config_test.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanupConfig_Defaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *CleanupConfig
+		expected CleanupConfig
+	}{
+		{
+			name:   "empty config should fill interval",
+			config: &CleanupConfig{},
+			expected: CleanupConfig{
+				Enabled:         false, // SetDefaultsはIntervalMinutesのみ設定
+				IntervalMinutes: 5,
+				IssueWindows: IssueWindowsConfig{
+					Enabled: false,
+				},
+			},
+		},
+		{
+			name: "config with interval set",
+			config: &CleanupConfig{
+				IntervalMinutes: 10,
+			},
+			expected: CleanupConfig{
+				Enabled:         false,
+				IntervalMinutes: 10, // 既に設定されているので変更なし
+				IssueWindows: IssueWindowsConfig{
+					Enabled: false,
+				},
+			},
+		},
+		{
+			name: "config with enabled true",
+			config: &CleanupConfig{
+				Enabled: true,
+			},
+			expected: CleanupConfig{
+				Enabled:         true,
+				IntervalMinutes: 5, // デフォルト値が設定される
+				IssueWindows: IssueWindowsConfig{
+					Enabled: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result CleanupConfig
+			if tt.config != nil {
+				result = *tt.config
+				t.Logf("Before SetDefaults: Enabled=%v, IntervalMinutes=%v, IssueWindows.Enabled=%v",
+					result.Enabled, result.IntervalMinutes, result.IssueWindows.Enabled)
+			}
+			result.SetDefaults()
+			t.Logf("After SetDefaults: Enabled=%v, IntervalMinutes=%v, IssueWindows.Enabled=%v",
+				result.Enabled, result.IntervalMinutes, result.IssueWindows.Enabled)
+
+			if result.Enabled != tt.expected.Enabled {
+				t.Errorf("Enabled = %v, want %v", result.Enabled, tt.expected.Enabled)
+			}
+			if result.IntervalMinutes != tt.expected.IntervalMinutes {
+				t.Errorf("IntervalMinutes = %v, want %v", result.IntervalMinutes, tt.expected.IntervalMinutes)
+			}
+			if result.IssueWindows.Enabled != tt.expected.IssueWindows.Enabled {
+				t.Errorf("IssueWindows.Enabled = %v, want %v", result.IssueWindows.Enabled, tt.expected.IssueWindows.Enabled)
+			}
+		})
+	}
+}
+
+func TestCleanupConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  CleanupConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config",
+			config: CleanupConfig{
+				Enabled:         true,
+				IntervalMinutes: 10,
+				IssueWindows: IssueWindowsConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "interval too small",
+			config: CleanupConfig{
+				Enabled:         true,
+				IntervalMinutes: 0,
+				IssueWindows: IssueWindowsConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: true,
+			errMsg:  "cleanup interval must be between 1 and 60 minutes",
+		},
+		{
+			name: "interval too large",
+			config: CleanupConfig{
+				Enabled:         true,
+				IntervalMinutes: 61,
+				IssueWindows: IssueWindowsConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: true,
+			errMsg:  "cleanup interval must be between 1 and 60 minutes",
+		},
+		{
+			name: "disabled cleanup is valid",
+			config: CleanupConfig{
+				Enabled:         false,
+				IntervalMinutes: 0, // Should not be validated when disabled
+				IssueWindows: IssueWindowsConfig{
+					Enabled: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "minimum valid interval",
+			config: CleanupConfig{
+				Enabled:         true,
+				IntervalMinutes: 1,
+				IssueWindows: IssueWindowsConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "maximum valid interval",
+			config: CleanupConfig{
+				Enabled:         true,
+				IntervalMinutes: 60,
+				IssueWindows: IssueWindowsConfig{
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("Validate() error message = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestCleanupConfig_GetInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   CleanupConfig
+		expected time.Duration
+	}{
+		{
+			name: "5 minutes",
+			config: CleanupConfig{
+				IntervalMinutes: 5,
+			},
+			expected: 5 * time.Minute,
+		},
+		{
+			name: "10 minutes",
+			config: CleanupConfig{
+				IntervalMinutes: 10,
+			},
+			expected: 10 * time.Minute,
+		},
+		{
+			name: "1 minute",
+			config: CleanupConfig{
+				IntervalMinutes: 1,
+			},
+			expected: 1 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.config.GetInterval()
+			if result != tt.expected {
+				t.Errorf("GetInterval() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/github/interface.go
+++ b/internal/github/interface.go
@@ -9,6 +9,7 @@ type GitHubClient interface {
 	GetRepository(ctx context.Context, owner, repo string) (*Repository, error)
 	ListIssuesByLabels(ctx context.Context, owner, repo string, labels []string) ([]*Issue, error)
 	ListAllOpenIssues(ctx context.Context, owner, repo string) ([]*Issue, error)
+	ListClosedIssues(ctx context.Context, owner, repo string) ([]*Issue, error)
 	ListPullRequestsByLabels(ctx context.Context, owner, repo string, labels []string) ([]*PullRequest, error)
 	GetRateLimit(ctx context.Context) (*RateLimits, error)
 	TransitionIssueLabel(ctx context.Context, owner, repo string, issueNumber int) (bool, error)

--- a/internal/testutil/mocks/github.go
+++ b/internal/testutil/mocks/github.go
@@ -152,6 +152,15 @@ func (m *MockGitHubClient) ListAllOpenIssues(ctx context.Context, owner, repo st
 	return args.Get(0).([]*github.Issue), args.Error(1)
 }
 
+// ListClosedIssues mocks the ListClosedIssues method
+func (m *MockGitHubClient) ListClosedIssues(ctx context.Context, owner, repo string) ([]*github.Issue, error) {
+	args := m.Called(ctx, owner, repo)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*github.Issue), args.Error(1)
+}
+
 // GetClosingIssueNumber mocks the GetClosingIssueNumber method
 func (m *MockGitHubClient) GetClosingIssueNumber(ctx context.Context, prNumber int) (int, error) {
 	args := m.Called(ctx, prNumber)

--- a/internal/watcher/auto_merge_test.go
+++ b/internal/watcher/auto_merge_test.go
@@ -79,6 +79,14 @@ func (m *MockGitHubClientForAutoMerge) TransitionLabels(ctx context.Context, own
 	return args.Error(0)
 }
 
+func (m *MockGitHubClientForAutoMerge) ListClosedIssues(ctx context.Context, owner, repo string) ([]*github.Issue, error) {
+	args := m.Called(ctx, owner, repo)
+	if issues := args.Get(0); issues != nil {
+		return issues.([]*github.Issue), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *MockGitHubClientForAutoMerge) GetPullRequestForIssue(ctx context.Context, issueNumber int) (*github.PullRequest, error) {
 	args := m.Called(ctx, issueNumber)
 	if args.Get(0) == nil {

--- a/internal/watcher/auto_plan_test.go
+++ b/internal/watcher/auto_plan_test.go
@@ -122,6 +122,14 @@ func (m *MockGitHubClientForAutoPlan) GetClosingIssueNumber(ctx context.Context,
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockGitHubClientForAutoPlan) ListClosedIssues(ctx context.Context, owner, repo string) ([]*github.Issue, error) {
+	args := m.Called(ctx, owner, repo)
+	if issues := args.Get(0); issues != nil {
+		return issues.([]*github.Issue), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func TestExecuteAutoPlanIfNoActiveIssues(t *testing.T) {
 	testLogger, _ := logger.New(logger.WithLevel("debug"))
 

--- a/internal/watcher/auto_revise_test.go
+++ b/internal/watcher/auto_revise_test.go
@@ -32,6 +32,14 @@ func (m *MockGitHubClientForAutoRevise) GetClosingIssueNumber(ctx context.Contex
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockGitHubClientForAutoRevise) ListClosedIssues(ctx context.Context, owner, repo string) ([]*github.Issue, error) {
+	args := m.Called(ctx, owner, repo)
+	if issues := args.Get(0); issues != nil {
+		return issues.([]*github.Issue), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *MockGitHubClientForAutoRevise) GetPullRequestForIssue(ctx context.Context, issueNumber int) (*github.PullRequest, error) {
 	args := m.Called(ctx, issueNumber)
 	if pr := args.Get(0); pr != nil {

--- a/internal/watcher/cleanup_watcher.go
+++ b/internal/watcher/cleanup_watcher.go
@@ -1,0 +1,145 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/douhashi/osoba/internal/cleanup"
+	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/logger"
+)
+
+// CleanupWatcher は定期的にクリーンアップを実行するウォッチャー
+type CleanupWatcher struct {
+	client         github.GitHubClient
+	owner          string
+	repo           string
+	interval       time.Duration
+	cleanupManager cleanup.Manager
+	logger         logger.Logger
+}
+
+// NewCleanupWatcher は新しいCleanupWatcherを作成する
+func NewCleanupWatcher(
+	client github.GitHubClient,
+	owner, repo string,
+	interval time.Duration,
+	cleanupManager cleanup.Manager,
+	logger logger.Logger,
+) (*CleanupWatcher, error) {
+	if client == nil {
+		return nil, errors.New("github client is required")
+	}
+	if owner == "" {
+		return nil, errors.New("owner is required")
+	}
+	if repo == "" {
+		return nil, errors.New("repo is required")
+	}
+	if interval <= 0 {
+		return nil, errors.New("interval must be positive")
+	}
+	if cleanupManager == nil {
+		return nil, errors.New("cleanup manager is required")
+	}
+
+	return &CleanupWatcher{
+		client:         client,
+		owner:          owner,
+		repo:           repo,
+		interval:       interval,
+		cleanupManager: cleanupManager,
+		logger:         logger,
+	}, nil
+}
+
+// Start はクリーンアップウォッチャーを開始する
+func (w *CleanupWatcher) Start(ctx context.Context) {
+	if w.logger != nil {
+		w.logger.Info("Starting cleanup watcher",
+			"owner", w.owner,
+			"repo", w.repo,
+			"interval", w.interval,
+		)
+	}
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	// 初回実行
+	w.performCleanup(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if w.logger != nil {
+				w.logger.Info("Cleanup watcher stopped")
+			}
+			return
+		case <-ticker.C:
+			w.performCleanup(ctx)
+		}
+	}
+}
+
+// performCleanup は実際のクリーンアップ処理を実行する
+func (w *CleanupWatcher) performCleanup(ctx context.Context) {
+	if w.logger != nil {
+		w.logger.Debug("Performing cleanup check")
+	}
+
+	// 閉じられたIssueを取得
+	closedIssues, err := w.client.ListClosedIssues(ctx, w.owner, w.repo)
+	if err != nil {
+		if w.logger != nil {
+			w.logger.Error("Failed to list closed issues",
+				"error", err,
+			)
+		}
+		return
+	}
+
+	if len(closedIssues) == 0 {
+		if w.logger != nil {
+			w.logger.Debug("No closed issues found")
+		}
+		return
+	}
+
+	if w.logger != nil {
+		w.logger.Info("Found closed issues for cleanup",
+			"count", len(closedIssues),
+		)
+	}
+
+	// 各Issueに対してクリーンアップを実行
+	for _, issue := range closedIssues {
+		if issue.Number == nil {
+			if w.logger != nil {
+				w.logger.Warn("Issue without number, skipping")
+			}
+			continue
+		}
+
+		issueNumber := *issue.Number
+
+		// クリーンアップ実行
+		if err := w.cleanupManager.CleanupIssueResources(ctx, issueNumber); err != nil {
+			if w.logger != nil {
+				w.logger.Error("Failed to cleanup issue resources",
+					"issue_number", issueNumber,
+					"error", err,
+				)
+			}
+			// エラーがあっても他のIssueの処理は続ける
+			continue
+		}
+
+		if w.logger != nil {
+			w.logger.Info("Successfully cleaned up issue resources",
+				"issue_number", issueNumber,
+			)
+		}
+	}
+}

--- a/internal/watcher/cleanup_watcher_test.go
+++ b/internal/watcher/cleanup_watcher_test.go
@@ -1,0 +1,347 @@
+package watcher
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/douhashi/osoba/internal/cleanup"
+	"github.com/douhashi/osoba/internal/github"
+	"github.com/douhashi/osoba/internal/logger"
+	"github.com/douhashi/osoba/internal/testutil/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestNullLogger はテスト用のnullロガー
+type TestNullLogger struct{}
+
+func (t *TestNullLogger) Debug(msg string, keysAndValues ...interface{}) {}
+func (t *TestNullLogger) Info(msg string, keysAndValues ...interface{})  {}
+func (t *TestNullLogger) Warn(msg string, keysAndValues ...interface{})  {}
+func (t *TestNullLogger) Error(msg string, keysAndValues ...interface{}) {}
+func (t *TestNullLogger) WithFields(keysAndValues ...interface{}) logger.Logger {
+	return t
+}
+
+// MockCleanupManagerForWatcher for testing cleanup watcher
+type MockCleanupManagerForWatcher struct {
+	mock.Mock
+}
+
+func (m *MockCleanupManagerForWatcher) CleanupIssueResources(ctx context.Context, issueNumber int) error {
+	args := m.Called(ctx, issueNumber)
+	return args.Error(0)
+}
+
+func TestCleanupWatcher_NewCleanupWatcher(t *testing.T) {
+	tests := []struct {
+		name       string
+		client     github.GitHubClient
+		owner      string
+		repo       string
+		interval   time.Duration
+		cleanupMgr cleanup.Manager
+		logger     logger.Logger
+		wantErr    bool
+	}{
+		{
+			name:       "valid parameters",
+			client:     &mocks.MockGitHubClient{},
+			owner:      "test-owner",
+			repo:       "test-repo",
+			interval:   1 * time.Minute,
+			cleanupMgr: &MockCleanupManagerForWatcher{},
+			logger:     &TestNullLogger{},
+			wantErr:    false,
+		},
+		{
+			name:       "nil client",
+			client:     nil,
+			owner:      "test-owner",
+			repo:       "test-repo",
+			interval:   1 * time.Minute,
+			cleanupMgr: &MockCleanupManagerForWatcher{},
+			logger:     &TestNullLogger{},
+			wantErr:    true,
+		},
+		{
+			name:       "empty owner",
+			client:     &mocks.MockGitHubClient{},
+			owner:      "",
+			repo:       "test-repo",
+			interval:   1 * time.Minute,
+			cleanupMgr: &MockCleanupManagerForWatcher{},
+			logger:     &TestNullLogger{},
+			wantErr:    true,
+		},
+		{
+			name:       "empty repo",
+			client:     &mocks.MockGitHubClient{},
+			owner:      "test-owner",
+			repo:       "",
+			interval:   1 * time.Minute,
+			cleanupMgr: &MockCleanupManagerForWatcher{},
+			logger:     &TestNullLogger{},
+			wantErr:    true,
+		},
+		{
+			name:       "invalid interval",
+			client:     &mocks.MockGitHubClient{},
+			owner:      "test-owner",
+			repo:       "test-repo",
+			interval:   0,
+			cleanupMgr: &MockCleanupManagerForWatcher{},
+			logger:     &TestNullLogger{},
+			wantErr:    true,
+		},
+		{
+			name:       "nil cleanup manager",
+			client:     &mocks.MockGitHubClient{},
+			owner:      "test-owner",
+			repo:       "test-repo",
+			interval:   1 * time.Minute,
+			cleanupMgr: nil,
+			logger:     &TestNullLogger{},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher, err := NewCleanupWatcher(tt.client, tt.owner, tt.repo, tt.interval, tt.cleanupMgr, tt.logger)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, watcher)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, watcher)
+			}
+		})
+	}
+}
+
+func TestCleanupWatcher_Start(t *testing.T) {
+	t.Run("periodic cleanup execution", func(t *testing.T) {
+		mockClient := new(mocks.MockGitHubClient)
+		mockManager := new(MockCleanupManagerForWatcher)
+
+		// 閉じられたIssueを返すモック
+		closedIssues := []*github.Issue{
+			{Number: intPtrForCleanup(1)},
+			{Number: intPtrForCleanup(2)},
+		}
+		mockClient.On("ListClosedIssues", mock.Anything, "owner", "repo").
+			Return(closedIssues, nil)
+
+		// クリーンアップの実行を期待
+		mockManager.On("CleanupIssueResources", mock.Anything, 1).Return(nil)
+		mockManager.On("CleanupIssueResources", mock.Anything, 2).Return(nil)
+
+		watcher, err := NewCleanupWatcher(
+			mockClient,
+			"owner",
+			"repo",
+			100*time.Millisecond, // 短い間隔でテスト
+			mockManager,
+			&TestNullLogger{},
+		)
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			watcher.Start(ctx)
+		}()
+
+		wg.Wait()
+
+		// 少なくとも1回は実行されることを確認
+		mockClient.AssertExpectations(t)
+		mockManager.AssertExpectations(t)
+	})
+
+	t.Run("context cancellation stops watcher", func(t *testing.T) {
+		mockClient := new(mocks.MockGitHubClient)
+		mockManager := new(MockCleanupManagerForWatcher)
+
+		// 初回実行のため空のリストを返す設定
+		mockClient.On("ListClosedIssues", mock.Anything, "owner", "repo").
+			Return([]*github.Issue{}, nil).Maybe()
+
+		watcher, err := NewCleanupWatcher(
+			mockClient,
+			"owner",
+			"repo",
+			1*time.Hour, // 長い間隔
+			mockManager,
+			&TestNullLogger{},
+		)
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			watcher.Start(ctx)
+		}()
+
+		// すぐにキャンセル
+		cancel()
+
+		// watcherが終了することを確認
+		done := make(chan bool)
+		go func() {
+			wg.Wait()
+			done <- true
+		}()
+
+		select {
+		case <-done:
+			// 正常に終了
+		case <-time.After(1 * time.Second):
+			t.Fatal("watcher did not stop after context cancellation")
+		}
+	})
+
+	t.Run("error handling in cleanup", func(t *testing.T) {
+		mockClient := new(mocks.MockGitHubClient)
+		mockManager := new(MockCleanupManagerForWatcher)
+
+		// 閉じられたIssueを返すモック
+		closedIssues := []*github.Issue{
+			{Number: intPtrForCleanup(1)},
+			{Number: intPtrForCleanup(2)},
+		}
+		mockClient.On("ListClosedIssues", mock.Anything, "owner", "repo").
+			Return(closedIssues, nil)
+
+		// 1つ目はエラー、2つ目は成功
+		mockManager.On("CleanupIssueResources", mock.Anything, 1).
+			Return(assert.AnError)
+		mockManager.On("CleanupIssueResources", mock.Anything, 2).
+			Return(nil)
+
+		watcher, err := NewCleanupWatcher(
+			mockClient,
+			"owner",
+			"repo",
+			100*time.Millisecond,
+			mockManager,
+			&TestNullLogger{},
+		)
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			watcher.Start(ctx)
+		}()
+
+		wg.Wait()
+
+		// エラーがあっても他のクリーンアップは実行される
+		mockClient.AssertExpectations(t)
+		mockManager.AssertExpectations(t)
+	})
+}
+
+func TestCleanupWatcher_performCleanup(t *testing.T) {
+	t.Run("cleanup closed issues", func(t *testing.T) {
+		mockClient := new(mocks.MockGitHubClient)
+		mockManager := new(MockCleanupManagerForWatcher)
+
+		closedIssues := []*github.Issue{
+			{Number: intPtrForCleanup(10)},
+			{Number: intPtrForCleanup(20)},
+		}
+		mockClient.On("ListClosedIssues", mock.Anything, "owner", "repo").
+			Return(closedIssues, nil)
+
+		mockManager.On("CleanupIssueResources", mock.Anything, 10).Return(nil)
+		mockManager.On("CleanupIssueResources", mock.Anything, 20).Return(nil)
+
+		watcher := &CleanupWatcher{
+			client:         mockClient,
+			owner:          "owner",
+			repo:           "repo",
+			interval:       1 * time.Minute,
+			cleanupManager: mockManager,
+			logger:         &TestNullLogger{},
+		}
+
+		watcher.performCleanup(context.Background())
+
+		mockClient.AssertExpectations(t)
+		mockManager.AssertExpectations(t)
+	})
+
+	t.Run("skip issues without number", func(t *testing.T) {
+		mockClient := new(mocks.MockGitHubClient)
+		mockManager := new(MockCleanupManagerForWatcher)
+
+		closedIssues := []*github.Issue{
+			{Number: nil}, // Numberがnil
+			{Number: intPtrForCleanup(30)},
+		}
+		mockClient.On("ListClosedIssues", mock.Anything, "owner", "repo").
+			Return(closedIssues, nil)
+
+		// Numberがnilのissueはスキップされる
+		mockManager.On("CleanupIssueResources", mock.Anything, 30).Return(nil)
+
+		watcher := &CleanupWatcher{
+			client:         mockClient,
+			owner:          "owner",
+			repo:           "repo",
+			interval:       1 * time.Minute,
+			cleanupManager: mockManager,
+			logger:         &TestNullLogger{},
+		}
+
+		watcher.performCleanup(context.Background())
+
+		mockClient.AssertExpectations(t)
+		mockManager.AssertExpectations(t)
+	})
+
+	t.Run("handle list issues error", func(t *testing.T) {
+		mockClient := new(mocks.MockGitHubClient)
+		mockManager := new(MockCleanupManagerForWatcher)
+
+		mockClient.On("ListClosedIssues", mock.Anything, "owner", "repo").
+			Return(nil, assert.AnError)
+
+		// エラーの場合、クリーンアップは実行されない
+
+		watcher := &CleanupWatcher{
+			client:         mockClient,
+			owner:          "owner",
+			repo:           "repo",
+			interval:       1 * time.Minute,
+			cleanupManager: mockManager,
+			logger:         &TestNullLogger{},
+		}
+
+		watcher.performCleanup(context.Background())
+
+		mockClient.AssertExpectations(t)
+		mockManager.AssertNotCalled(t, "CleanupIssueResources", mock.Anything, mock.Anything)
+	})
+}
+
+// Helper function for creating int pointers (cleanup watcher)
+func intPtrForCleanup(i int) *int {
+	return &i
+}

--- a/internal/watcher/integration_test.go
+++ b/internal/watcher/integration_test.go
@@ -390,6 +390,18 @@ func (m *integrationMockGitHubClient) GetClosingIssueNumber(ctx context.Context,
 	return 0, nil
 }
 
+func (m *integrationMockGitHubClient) ListClosedIssues(ctx context.Context, owner, repo string) ([]*github.Issue, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.returnError {
+		return nil, errors.New("mock error")
+	}
+
+	// 空のリストを返す
+	return []*github.Issue{}, nil
+}
+
 // 既存の統合テスト（mainブランチから）
 func TestStartWithActionsIntegration(t *testing.T) {
 	t.Run("複数のIssueを連続して処理", func(t *testing.T) {

--- a/internal/watcher/label_transition_test.go
+++ b/internal/watcher/label_transition_test.go
@@ -117,6 +117,14 @@ func (m *MockGitHubClient) GetClosingIssueNumber(ctx context.Context, prNumber i
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockGitHubClient) ListClosedIssues(ctx context.Context, owner, repo string) ([]*github.Issue, error) {
+	args := m.Called(ctx, owner, repo)
+	if issues := args.Get(0); issues != nil {
+		return issues.([]*github.Issue), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func TestExecuteLabelTransition(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary
- Issue #349 の実装：クリーンアップ機能の設定管理を追加
- 設定ファイル（config.yaml）でクリーンアップ機能の有効/無効と実行間隔を制御できるように
- 定期的に閉じられたIssueに関連するリソース（tmuxウィンドウ、git worktree）を自動クリーンアップ

## Changes
### 設定管理
- `CleanupConfig`構造体を追加し、設定管理を実装
- クリーンアップの有効/無効（`enabled`）を設定可能
- 実行間隔（`interval_minutes`）を1〜60分の範囲で設定可能
- デフォルト値：enabled=true、interval=5分

### CleanupWatcher実装
- 定期的にクリーンアップを実行する`CleanupWatcher`を実装
- 閉じられたIssueを取得し、関連リソースをクリーンアップ
- コンテキストによる適切な終了処理をサポート

### GitHubClient拡張
- `ListClosedIssues`メソッドを追加
- gh CLIを使用して閉じられたIssueのリストを取得

### テスト
- CleanupConfigの包括的なテストを追加
- CleanupWatcherのテストを追加
- 全てのMockGitHubClientを更新し、新しいインターフェースに対応

## Test plan
- [x] `go test ./internal/config -run TestCleanupConfig`：設定のテスト
- [x] `go test ./internal/watcher -run TestCleanupWatcher`：CleanupWatcherのテスト
- [x] `go test ./...`：全体のテストスイート実行
- [ ] 手動テスト：実際に設定を有効にして動作確認

## Related Issues
Closes #349

🤖 Generated with [Claude Code](https://claude.ai/code)