### PR TITLE
feat: Issueウィンドウ自動クリーンアップサービス (#350)

### DIFF
--- a/cmd/templates/config.yml
+++ b/cmd/templates/config.yml
@@ -10,6 +10,17 @@ github:
   # デフォルト: false（無効）
   # auto_plan_issue: false
 
+# クリーンアップ機能の設定
+cleanup:
+  # クリーンアップ機能の有効/無効（デフォルト: true）
+  enabled: true
+  # クリーンアップ実行間隔（分）（デフォルト: 5）
+  interval_minutes: 5
+  # Issueウィンドウのクリーンアップ設定
+  issue_windows:
+    # クローズされたIssueのウィンドウを自動削除（デフォルト: true）
+    enabled: true
+
 tmux:
   session_prefix: "osoba-"
   # ウィンドウ内のペイン数上限（デフォルト: 3）


### PR DESCRIPTION
## 実装完了

以下のIssueについて、TDDに基づき実装を完了しました。

- Issue: fixes #350
- 対応内容:
  - 設定ファイルテンプレート（`cmd/templates/config.yml`）にcleanupセクションを追加
  - startコマンドにCleanupWatcher統合を実装し、設定に基づいて自動起動
  - クリーンアップ機能の有効/無効と実行間隔を設定ファイルで制御可能に
- 実装方式: テスト駆動開発（TDD）に準拠
- テスト状況:
  - 単体テスト: ✅ パス（CleanupConfig、CleanupWatcher、cleanupパッケージ）
  - 結合テスト: ✅ パス（startコマンドの統合テスト）
  - フルテスト: ✅ パス（関連パッケージのテストが成功）

## 変更内容

### 設定ファイルテンプレートの更新
- `cmd/templates/config.yml`に`cleanup`セクションを追加
- デフォルト値とコメントで機能説明を記載

### startコマンドへの統合
- `cmd/start.go`でCleanupWatcherを作成・起動する処理を追加
- 設定の`cleanup.enabled`と`cleanup.issue_windows.enabled`がtrueの場合のみ起動
- クリーンアップ間隔は設定の`cleanup.interval_minutes`から取得（デフォルト: 5分）

## 動作確認方法

1. 設定ファイルでクリーンアップ機能を有効化:
```yaml
cleanup:
  enabled: true
  interval_minutes: 5
  issue_windows:
    enabled: true
```

2. `osoba start`コマンドを実行
3. ログに「クリーンアップ監視を開始します」が表示されることを確認
4. GitHubでIssueをクローズ
5. 5分後に該当するTmuxウィンドウが自動削除されることを確認

ご確認のほどよろしくお願いいたします。